### PR TITLE
refactor: should skip static

### DIFF
--- a/crates/ef-testing/src/lib.rs
+++ b/crates/ef-testing/src/lib.rs
@@ -3,8 +3,6 @@ pub mod storage;
 pub mod traits;
 pub mod utils;
 
-use std::path::Path;
-
 use bytes::BytesMut;
 use kakarot_rpc_core::client::constants::CHAIN_ID;
 use reth_primitives::{sign_message, Bytes, SealedBlock, Signature, Transaction};
@@ -40,84 +38,4 @@ pub fn get_signed_rlp_encoded_transaction(
     tx_signed.encode_with_signature(&signature, &mut out, true);
 
     Ok(out.to_vec().into())
-}
-
-/// returns whether a given test at a given path should be skipped or not
-pub fn should_skip(path: &Path) -> bool {
-    let path_str = path.to_str().expect("Path is not valid UTF-8");
-    let name = path.file_name().unwrap().to_str().unwrap();
-
-    // list of files that we do want to include even though their parent directories might be marked for skip
-    let include_files = [
-        "ethereum-tests/BlockchainTests/GeneralStateTests/VMTests/vmArithmeticTest/add.json",
-        "ethereum-tests/BlockchainTests/GeneralStateTests/VMTests/vmArithmeticTest/mul.json",
-    ];
-    for file_path in include_files {
-        if path_str.contains(file_path) {
-            return false;
-        }
-    }
-
-    matches!(
-        name,
-        // A case can be added like this
-        // | "testFileName.json"
-        // using "" as a placeholder till we get our first filename to ignore
-        | ""
-    ) || path_contains(
-        path_str,
-        &[
-            "ABITests",
-            "BasicTests",
-            "BlockchainTests",
-            "DifficultyTests",
-            "EIPTests",
-            "EOFTests",
-            "GenesisTests",
-            "JSONSchema",
-            "KeyStoreTests",
-            "LegacyTests",
-            "PoWTests",
-            "RLPTests",
-            "TransactionTests",
-            "TrieTests",
-        ],
-    )
-}
-
-/// returns whether a path is part from a list of directories
-fn path_contains(path_str: &str, dirs: &[&str]) -> bool {
-    for value in dirs {
-        if path_str.contains(value) {
-            return true;
-        }
-    }
-    false
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::Path;
-
-    use crate::should_skip;
-
-    #[tokio::test]
-    async fn test_should_skip() {
-        // should be skipped since BasicTests is ignored
-        let path = Path::new("ethereum-tests/BasicTests/blockgenesistest.json");
-
-        assert!(should_skip(path));
-
-        // should not be skipped although BlockchainTests dir has been ignored, since it is included in `include_files`
-        let path = Path::new(
-            "ethereum-tests/BlockchainTests/GeneralStateTests/VMTests/vmArithmeticTest/add.json",
-        );
-        assert!(!should_skip(path));
-
-        // should not be skipped although BlockchainTests dir has been ignored, since it is included in `include_files`
-        let path = Path::new(
-            "ethereum-tests/BlockchainTests/GeneralStateTests/VMTests/vmArithmeticTest/mul.json",
-        );
-        assert!(!should_skip(path));
-    }
 }

--- a/crates/ef-testing/src/traits/mod.rs
+++ b/crates/ef-testing/src/traits/mod.rs
@@ -2,7 +2,7 @@
 //! Inspired by https://github.com/paradigmxyz/reth/tree/main/testing/ef-tests
 
 use async_trait::async_trait;
-use ef_tests::{cases::blockchain_test::should_skip, result::Error};
+use ef_tests::result::Error;
 use std::{
     fmt::Debug,
     path::{Path, PathBuf},
@@ -50,11 +50,6 @@ pub trait Suite {
 
         // todo: assert that the path exists
         let test_cases_paths = find_all_files_with_extension(&suite_path, ".json");
-        let test_cases_paths: Vec<PathBuf> = test_cases_paths
-            .iter()
-            .filter(|test_case_path| !should_skip(test_case_path))
-            .cloned()
-            .collect();
 
         let mut test_cases = Vec::new();
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Make the `should_skip` method a static of `BlockChainTest`, filtering only on the particular test name. Further updates could be done to filter on subtests.

Time spent on this PR: 0.1 day

Resolves: #23 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [x] Refactoring (no functional changes, no API changes)
-   [ ] Build-related changes
-   [ ] Documentation content changes
-   [ ] Testing

# What is the new behavior?
`shoud_skip` is made into a static method.

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
