### PR TITLE
fix: add evm -> starknet address in pre state

### DIFF
--- a/crates/ef-testing/src/storage/kakarot.rs
+++ b/crates/ef-testing/src/storage/kakarot.rs
@@ -1,0 +1,13 @@
+use starknet::core::types::FieldElement;
+use starknet_api::{hash::StarkFelt, state::StorageKey};
+
+use crate::models::error::RunnerError;
+
+use super::starknet_storage_key_value;
+
+pub(crate) fn generate_evm_to_starknet_address(
+    evm_address: FieldElement,
+    starknet_address: FieldElement,
+) -> Result<(StorageKey, StarkFelt), RunnerError> {
+    starknet_storage_key_value("evm_to_starknet_address", &[evm_address], starknet_address)
+}

--- a/crates/ef-testing/src/storage/mod.rs
+++ b/crates/ef-testing/src/storage/mod.rs
@@ -1,6 +1,7 @@
 pub mod contract;
 pub mod eoa;
 pub mod fee_token;
+pub mod kakarot;
 pub mod models;
 
 use ef_tests::models::Account;
@@ -24,6 +25,7 @@ use tokio::sync::RwLockWriteGuard;
 
 use crate::{models::error::RunnerError, utils::starknet::get_starknet_storage_key};
 
+use self::kakarot::generate_evm_to_starknet_address;
 use self::{
     contract::{generate_evm_contract_storage, initialize_contract_account},
     eoa::initialize_eoa,
@@ -39,16 +41,20 @@ pub fn write_test_state(
     starknet: &mut RwLockWriteGuard<'_, MemDb>,
 ) -> Result<(), RunnerError> {
     // iterate through pre-state addresses
+    let mut kakarot_storage = Vec::new();
     for (address, account_info) in state.iter() {
         let mut starknet_contract_storage = Vec::new();
         let address = Felt252Wrapper::from(address.to_owned()).into();
         let starknet_address =
             compute_starknet_address(kakarot_address, class_hashes.proxy_class_hash, address);
 
+        // Push the kakarot state
+        kakarot_storage.push(generate_evm_to_starknet_address(address, starknet_address)?);
+
         // Write evm storage
         starknet_contract_storage.append(&mut generate_evm_contract_storage(account_info)?);
 
-        // get the implementation class hash and initialize the account
+        // Get the implementation class hash and initialize the account
         let proxy_implementation_class_hash = if is_account_eoa(account_info) {
             starknet_contract_storage.append(&mut initialize_eoa(kakarot_address, address)?);
             class_hashes.eoa_class_hash
@@ -85,19 +91,13 @@ pub fn write_test_state(
             starknet_address,
             account_info.balance.0,
         )?;
-        let address =
-            StarknetContractAddress(Into::<StarkFelt>::into(*FEE_TOKEN_ADDRESS).try_into()?);
-        for (k, v) in fee_token_storage.iter() {
-            starknet
-                .storage
-                .get_mut(&address)
-                .ok_or_else(|| {
-                    RunnerError::Other(format!("missing fee token address {:?}", address))
-                })?
-                .storage
-                .insert(*k, *v);
-        }
+        let fee_token_address: StarkFelt = *FEE_TOKEN_ADDRESS;
+        extend_starknet_state_with_storage(fee_token_address.into(), fee_token_storage, starknet)?;
     }
+
+    // Update the sequencer state with the kakarot state
+    extend_starknet_state_with_storage(kakarot_address, kakarot_storage, starknet)?;
+
     Ok(())
 }
 
@@ -113,6 +113,21 @@ pub fn madara_to_katana_storage(
             Ok((key, value))
         })
         .collect()
+}
+
+pub(crate) fn extend_starknet_state_with_storage(
+    address: FieldElement,
+    storage: Vec<(StarknetStorageKey, StarkFelt)>,
+    starknet: &mut RwLockWriteGuard<'_, MemDb>,
+) -> Result<(), RunnerError> {
+    let address = StarknetContractAddress(Into::<StarkFelt>::into(address).try_into()?);
+    starknet
+        .storage
+        .get_mut(&address)
+        .ok_or_else(|| RunnerError::Other(format!("missing address {:?} in storage", address)))?
+        .storage
+        .extend(storage);
+    Ok(())
 }
 
 pub(crate) fn starknet_storage_key_value(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Adds the mapping from evm to starknet address in the pre state, which was added in Kakarot in commit [b6619ad](https://github.com/kkrt-labs/kakarot/commit/b6619adb6092984f4c6b4fa512ebf07ec8d47299).

Time spent on this PR: 0.2 day

Resolves: #73 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no API changes)
-   [ ] Build-related changes
-   [ ] Documentation content changes
-   [ ] Testing

# What is the new behavior?
Can run all previous passing tests.

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
