### PR TITLE
Feat: rebase sequencer on blockifier fork

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.16.2
+  version: 1.17.1
 plugins:
   sources:
     - id: trunk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,8 +501,7 @@ dependencies = [
 [[package]]
 name = "bincode"
 version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+source = "git+https://github.com/bincode-org/bincode.git?tag=v2.0.0-rc.3#aada4bb4cb457677a4b8e47572ae7ca8dd44927c"
 dependencies = [
  "serde",
 ]
@@ -650,7 +649,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.3.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier.git?tag=v0.3.0-rc0#72087fe729a950f284189fa74304824e7c1c99ee"
+source = "git+https://github.com/kkrt-labs/blockifier.git?branch=v0.3.0-rc0#5115a78272e31ea5db4423179dda8330f1986dff"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -919,9 +918,8 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cairo-felt"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5972097b8800ca5dffb458040e74c724a2ac4fa4b5b480b50f5b96c7e67d6427"
+version = "0.8.2"
+source = "git+https://github.com/kkrt-labs/cairo-vm.git?branch=v0.8.2#2105b7c2f6c37d003ae7a4e0c531e8a3233eb5f2"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -1389,9 +1387,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d9bf139b0fe845627cf09d11af43eec9575dba702033bf6b08050c776b8553"
+version = "0.8.2"
+source = "git+https://github.com/kkrt-labs/cairo-vm.git?branch=v0.8.2#2105b7c2f6c37d003ae7a4e0c531e8a3233eb5f2"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ revm-primitives = "1.1"
 reth-rlp = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.1.0-alpha.7" }
 
 # Starknet deps
-cairo-vm = "0.8.2"
+cairo-vm = "=0.8.2"
 blockifier = { package = "blockifier", git = "https://github.com/starkware-libs/blockifier.git", tag = "v0.3.0-rc0" }
 starknet = "0.6.0"
 starknet_api = "0.5.0-rc1"
@@ -66,6 +66,12 @@ log4rs = "1.2.0"
 [patch."https://github.com/ethereum/c-kzg-4844"]
 c-kzg = { git = "https://github.com/rjected/c-kzg-4844", branch = "dan/add-serde-feature" }
 
+[patch."https://github.com/starkware-libs/blockifier.git"]
+blockifier = { package = "blockifier", git = "https://github.com/kkrt-labs/blockifier.git", branch = "v0.3.0-rc0" }
+
+
 [patch.crates-io]
 revm = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }
 revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }
+cairo-felt = { git = "https://github.com/kkrt-labs/cairo-vm.git", branch = "v0.8.2" }
+cairo-vm = { git = "https://github.com/kkrt-labs/cairo-vm.git", branch = "v0.8.2" }

--- a/crates/ef-testing/src/evm_sequencer/evm_state.rs
+++ b/crates/ef-testing/src/evm_sequencer/evm_state.rs
@@ -109,7 +109,7 @@ impl EvmState for KakarotSequencer {
         for ((var, keys), v) in storage {
             (&mut self.0.state).set_storage_at(
                 starknet_address,
-                get_storage_var_address(var, &keys), // safe unwrap: all vars are ASCII
+                get_storage_var_address(var, &keys),
                 v,
             );
         }

--- a/crates/ef-testing/src/evm_sequencer/evm_state.rs
+++ b/crates/ef-testing/src/evm_sequencer/evm_state.rs
@@ -109,7 +109,7 @@ impl EvmState for KakarotSequencer {
         for ((var, keys), v) in storage {
             (&mut self.0.state).set_storage_at(
                 starknet_address,
-                get_storage_var_address(var, &keys).unwrap(), // safe unwrap: all vars are ASCII
+                get_storage_var_address(var, &keys), // safe unwrap: all vars are ASCII
                 v,
             );
         }
@@ -120,7 +120,7 @@ impl EvmState for KakarotSequencer {
         // Add the address to the Kakarot evm to starknet mapping
         (&mut self.0.state).set_storage_at(
             *KAKAROT_ADDRESS,
-            get_storage_var_address("evm_to_starknet_address", &[evm_address]).unwrap(),
+            get_storage_var_address("evm_to_starknet_address", &[evm_address]),
             *starknet_address.0.key(),
         );
         Ok(())
@@ -185,7 +185,7 @@ impl EvmState for KakarotSequencer {
         let implementation = (&mut self.0.state)
             .get_storage_at(
                 starknet_address.try_into()?,
-                get_storage_var_address("_implementation", &[])?,
+                get_storage_var_address("_implementation", &[]),
             )
             .unwrap();
 
@@ -194,7 +194,7 @@ impl EvmState for KakarotSequencer {
                 .get_nonce_at(starknet_address.try_into()?)?
                 .0
         } else if implementation == CONTRACT_ACCOUNT_CLASS_HASH.0 {
-            let key = get_storage_var_address("nonce", &[])?;
+            let key = get_storage_var_address("nonce", &[]);
             (&mut self.0.state).get_storage_at(starknet_address.try_into()?, key)?
         } else {
             // We can't throw an error here, because it could just be an uninitialized account.
@@ -214,7 +214,7 @@ impl EvmState for KakarotSequencer {
 
         let bytecode_len = (&mut self.0.state).get_storage_at(
             starknet_address.try_into()?,
-            get_storage_var_address("bytecode_len_", &[])?,
+            get_storage_var_address("bytecode_len_", &[]),
         )?;
         let bytecode_len: u64 = bytecode_len.try_into()?;
         if bytecode_len == 0 {
@@ -226,13 +226,13 @@ impl EvmState for KakarotSequencer {
         let mut bytecode: Vec<u8> = Vec::new();
 
         for chunk_index in 0..num_chunks {
-            let key = get_storage_var_address("bytecode_", &[StarkFelt::from(chunk_index)])?;
+            let key = get_storage_var_address("bytecode_", &[StarkFelt::from(chunk_index)]);
             let code = (&mut self.0.state).get_storage_at(starknet_address.try_into()?, key)?;
             bytecode.append(&mut high_16_bytes_of_felt_to_bytes(&code.into(), 16).to_vec());
         }
 
         let remainder = bytecode_len % 16;
-        let key = get_storage_var_address("bytecode_", &[StarkFelt::from(num_chunks)])?;
+        let key = get_storage_var_address("bytecode_", &[StarkFelt::from(num_chunks)]);
         let code = (&mut self.0.state).get_storage_at(starknet_address.try_into()?, key)?;
         bytecode
             .append(&mut high_16_bytes_of_felt_to_bytes(&code.into(), remainder as usize).to_vec());
@@ -324,8 +324,7 @@ mod tests {
         let storage = (&mut sequencer.0.state)
             .get_storage_at(
                 contract_starknet_address,
-                get_storage_var_address("storage_", &[StarkFelt::from(0u8), StarkFelt::from(0u8)])
-                    .unwrap(),
+                get_storage_var_address("storage_", &[StarkFelt::from(0u8), StarkFelt::from(0u8)]),
             )
             .unwrap();
         assert_eq!(storage, StarkFelt::from(1u8));

--- a/crates/ef-testing/src/evm_sequencer/mod.rs
+++ b/crates/ef-testing/src/evm_sequencer/mod.rs
@@ -45,7 +45,7 @@ impl KakarotSequencer {
         for (k, v) in storage {
             (&mut self.0.state).set_storage_at(
                 *KAKAROT_ADDRESS,
-                get_storage_var_address(k, &[]).unwrap(), // safe unwrap: all vars are ASCII
+                get_storage_var_address(k, &[]), // safe unwrap: all vars are ASCII
                 v,
             );
         }

--- a/crates/ef-testing/src/evm_sequencer/mod.rs
+++ b/crates/ef-testing/src/evm_sequencer/mod.rs
@@ -45,7 +45,7 @@ impl KakarotSequencer {
         for (k, v) in storage {
             (&mut self.0.state).set_storage_at(
                 *KAKAROT_ADDRESS,
-                get_storage_var_address(k, &[]), // safe unwrap: all vars are ASCII
+                get_storage_var_address(k, &[]),
                 v,
             );
         }

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -263,10 +263,7 @@ mod tests {
         // Then
         let expected = StarkFelt::from(1u8);
         let actual = (&mut sequencer.state)
-            .get_storage_at(
-                *TEST_CONTRACT,
-                get_storage_var_address("counter", &[]),
-            )
+            .get_storage_at(*TEST_CONTRACT, get_storage_var_address("counter", &[]))
             .unwrap();
         assert_eq!(expected, actual);
     }
@@ -303,10 +300,7 @@ mod tests {
         // Then
         let expected = StarkFelt::from(1u8);
         let actual = (&mut sequencer.state)
-            .get_storage_at(
-                *TEST_CONTRACT,
-                get_storage_var_address("counter", &[]),
-            )
+            .get_storage_at(*TEST_CONTRACT, get_storage_var_address("counter", &[]))
             .unwrap();
         assert_eq!(expected, actual);
     }

--- a/crates/sequencer/src/sequencer.rs
+++ b/crates/sequencer/src/sequencer.rs
@@ -164,7 +164,7 @@ mod tests {
     fn fund(address: StarkFelt, mut state: &mut State) {
         state.set_storage_at(
             *ETH_FEE_TOKEN_ADDRESS,
-            get_storage_var_address("ERC20_balances", &[address]).unwrap(),
+            get_storage_var_address("ERC20_balances", &[address]),
             StarkFelt::from(u128::MAX),
         );
     }
@@ -265,7 +265,7 @@ mod tests {
         let actual = (&mut sequencer.state)
             .get_storage_at(
                 *TEST_CONTRACT,
-                get_storage_var_address("counter", &[]).unwrap(),
+                get_storage_var_address("counter", &[]),
             )
             .unwrap();
         assert_eq!(expected, actual);
@@ -305,7 +305,7 @@ mod tests {
         let actual = (&mut sequencer.state)
             .get_storage_at(
                 *TEST_CONTRACT,
-                get_storage_var_address("counter", &[]).unwrap(),
+                get_storage_var_address("counter", &[]),
             )
             .unwrap();
         assert_eq!(expected, actual);


### PR DESCRIPTION
# Pull Request type

This pr enables our sequencer to work on top of our own blockifier and cairo-vm fork.

Resolves: #546 

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

## What is the new behavior?

The codebase has been rebased on top of our own blockifier and cairo-vm fork.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
