### PR TITLE
feat: only sender account is an EOA in tests

### DIFF
--- a/crates/ef-testing/src/evm_sequencer/account/mod.rs
+++ b/crates/ef-testing/src/evm_sequencer/account/mod.rs
@@ -75,6 +75,7 @@ pub mod kkrt_account {
             _code: &Bytes,
             _nonce: U256,
             _evm_storage: &[(U256, U256)],
+            _is_eoa: bool
         ) -> Result<Self, StarknetApiError> {
             Ok(Self {
                 evm_address: StarkFelt::default(),

--- a/crates/ef-testing/src/evm_sequencer/account/mod.rs
+++ b/crates/ef-testing/src/evm_sequencer/account/mod.rs
@@ -75,7 +75,7 @@ pub mod kkrt_account {
             _code: &Bytes,
             _nonce: U256,
             _evm_storage: &[(U256, U256)],
-            _is_eoa: bool
+            _is_eoa: bool,
         ) -> Result<Self, StarknetApiError> {
             Ok(Self {
                 evm_address: StarkFelt::default(),

--- a/crates/ef-testing/src/evm_sequencer/account/v0.rs
+++ b/crates/ef-testing/src/evm_sequencer/account/v0.rs
@@ -12,6 +12,7 @@ impl KakarotAccount {
         code: &Bytes,
         nonce: U256,
         evm_storage: &[(U256, U256)],
+        is_eoa: bool,
     ) -> Result<Self, StarknetApiError> {
         let nonce = StarkFelt::from(TryInto::<u128>::try_into(nonce).map_err(|err| {
             StarknetApiError::OutOfRange {
@@ -30,9 +31,8 @@ impl KakarotAccount {
         ];
 
         // Initialize the implementation and nonce based on account type.
-        // The account is an EOA if it has no bytecode and no storage (or all storage is zero).
-        let has_code_or_storage = !code.is_empty() || evm_storage.iter().any(|x| x.1 != U256::ZERO);
-        let account_type = if !has_code_or_storage {
+        // In tests, only the sender is an EOA.
+        let account_type = if is_eoa {
             AccountType::EOA
         } else {
             storage.append(&mut vec![starknet_storage!("nonce", nonce)]);

--- a/crates/ef-testing/src/evm_sequencer/account/v0.rs
+++ b/crates/ef-testing/src/evm_sequencer/account/v0.rs
@@ -12,7 +12,7 @@ impl KakarotAccount {
         code: &Bytes,
         nonce: U256,
         evm_storage: &[(U256, U256)],
-        is_eoa: bool,
+        is_eoa: bool
     ) -> Result<Self, StarknetApiError> {
         let nonce = StarkFelt::from(TryInto::<u128>::try_into(nonce).map_err(|err| {
             StarknetApiError::OutOfRange {

--- a/crates/ef-testing/src/evm_sequencer/account/v0.rs
+++ b/crates/ef-testing/src/evm_sequencer/account/v0.rs
@@ -12,7 +12,7 @@ impl KakarotAccount {
         code: &Bytes,
         nonce: U256,
         evm_storage: &[(U256, U256)],
-        is_eoa: bool
+        is_eoa: bool,
     ) -> Result<Self, StarknetApiError> {
         let nonce = StarkFelt::from(TryInto::<u128>::try_into(nonce).map_err(|err| {
             StarknetApiError::OutOfRange {

--- a/crates/ef-testing/src/evm_sequencer/account/v1.rs
+++ b/crates/ef-testing/src/evm_sequencer/account/v1.rs
@@ -41,7 +41,7 @@ impl KakarotAccount {
         let account_type = if is_eoa {
             AccountType::EOA
         } else {
-            storage.append(&mut vec![starknet_storage!("nonce", nonce)]);
+            storage.push(starknet_storage!("contract_account_nonce", nonce));
             AccountType::Contract
         };
 

--- a/crates/ef-testing/src/evm_sequencer/evm_state/v0.rs
+++ b/crates/ef-testing/src/evm_sequencer/evm_state/v0.rs
@@ -335,8 +335,9 @@ mod tests {
         let nonce = U256::from(0);
 
         // When
-        let contract = KakarotAccount::new(&TEST_CONTRACT_ADDRESS, &bytecode, nonce, &[]).unwrap();
-        let eoa = KakarotAccount::new(&PUBLIC_KEY, &Bytes::default(), nonce, &[]).unwrap();
+        let contract =
+            KakarotAccount::new(&TEST_CONTRACT_ADDRESS, &bytecode, nonce, &[], false).unwrap();
+        let eoa = KakarotAccount::new(&PUBLIC_KEY, &Bytes::default(), nonce, &[], true).unwrap();
         sequencer.setup_account(contract).unwrap();
         sequencer.setup_account(eoa).unwrap();
         sequencer.execute_transaction(transaction).unwrap();

--- a/crates/ef-testing/src/evm_sequencer/evm_state/v1.rs
+++ b/crates/ef-testing/src/evm_sequencer/evm_state/v1.rs
@@ -40,7 +40,8 @@ impl Evm for KakarotSequencer {
     /// Sets up the evm state (coinbase, block number, etc.)
     fn setup_state(&mut self, _base_fee: U256) -> StateResult<()> {
         let coinbase_address = *self.address();
-        let coinbase = KakarotAccount::new(&coinbase_address, &Bytes::default(), U256::ZERO, &[])?;
+        let coinbase =
+            KakarotAccount::new(&coinbase_address, &Bytes::default(), U256::ZERO, &[], true)?;
         self.setup_account(coinbase)?;
         self.fund(&coinbase_address, U256::ZERO)?;
 
@@ -383,7 +384,7 @@ mod tests {
 
         // When
         let account =
-            KakarotAccount::new(&TEST_CONTRACT_ADDRESS, &bytecode, U256::ZERO, &[]).unwrap();
+            KakarotAccount::new(&TEST_CONTRACT_ADDRESS, &bytecode, U256::ZERO, &[], false).unwrap();
         sequencer.setup_account(account).unwrap();
 
         // Then
@@ -437,8 +438,8 @@ mod tests {
         ]); // PUSH 01 PUSH 00 SSTORE
         let nonce = U256::from(0);
         let contract_account =
-            KakarotAccount::new(&TEST_CONTRACT_ADDRESS, &bytecode, nonce, &[]).unwrap();
-        let eoa = KakarotAccount::new(&PUBLIC_KEY, &Bytes::default(), nonce, &[]).unwrap();
+            KakarotAccount::new(&TEST_CONTRACT_ADDRESS, &bytecode, nonce, &[], false).unwrap();
+        let eoa = KakarotAccount::new(&PUBLIC_KEY, &Bytes::default(), nonce, &[], true).unwrap();
         sequencer.setup_account(contract_account).unwrap();
         sequencer.setup_account(eoa).unwrap();
         sequencer.execute_transaction(transaction).unwrap();

--- a/crates/ef-testing/src/models/case.rs
+++ b/crates/ef-testing/src/models/case.rs
@@ -70,13 +70,6 @@ impl BlockchainTestCase {
                 &account.storage.clone().into_iter().collect::<Vec<_>>()[..],
                 is_eoa,
             )?;
-            // Override the account type - in tests, only the sender is an EOA. All other accounts are contracts.
-            kakarot_account.account_type = if address.0 == sender_address {
-                AccountType::EOA
-            } else {
-                AccountType::Contract
-            };
-
             sequencer.setup_account(kakarot_account)?;
             sequencer.fund(address, account.balance)?;
         }

--- a/crates/ef-testing/src/models/case.rs
+++ b/crates/ef-testing/src/models/case.rs
@@ -1,7 +1,6 @@
 // Inspired by https://github.com/paradigmxyz/reth/tree/main/testing/ef-tests
 use super::error::RunnerError;
 use super::result::{extract_execution_retdata, log_execution_result};
-use crate::evm_sequencer::account::AccountType;
 use crate::evm_sequencer::constants::{
     CONTRACT_ACCOUNT_CLASS_HASH, EOA_CLASS_HASH, KAKAROT_ADDRESS, PROXY_CLASS_HASH,
 };
@@ -63,7 +62,7 @@ impl BlockchainTestCase {
 
         for (address, account) in self.pre.iter() {
             let is_eoa = address.0 == sender_address;
-            let mut kakarot_account = KakarotAccount::new(
+            let kakarot_account = KakarotAccount::new(
                 address,
                 &account.code,
                 account.nonce,

--- a/crates/ef-testing/src/models/result.rs
+++ b/crates/ef-testing/src/models/result.rs
@@ -70,6 +70,11 @@ pub(crate) fn log_execution_result(
         TransactionExecutionResult::Err(TransactionExecutionError::ValidateTransactionError(
             EntryPointExecutionError::VirtualMachineExecutionErrorWithTrace { trace, .. },
         )) => {
+            // There are specific test cases where validation failed because the sender account has code.
+            // They're caught by EOA validation, and rejected with this specific error message.
+            if trace.contains("EOAs cannot have code") {
+                return;
+            }
             let re = regex::Regex::new(
                 r#"Error in the called contract \((0x[0-9a-zA-Z]+)\)[\s\S]*?EntryPointSelector\(StarkFelt\("(0x[0-9a-zA-Z]+)"\)\)"#,
             ).unwrap();


### PR DESCRIPTION
# Pull Request type

<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.2d

Only the sender of a transaction should be an EOA - otherwise, this creates conflicts when loading accounts assumed to be EOAs because they have no code or storage, but they're just CAs waiting to be deployed and are in state because of a non-empty balance.

<!-- Please try to limit your pull request to one type;
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
