### PR TITLE
dev: use the hashbrown crate for hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6484,8 +6484,8 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "eyre",
+ "hashbrown 0.14.3",
  "lazy_static",
- "rustc-hash",
  "serde",
  "serde_json",
  "starknet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ zip = "0.6.6"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9.25"
-
+hashbrown = "0.14.3"
 # Log
 log = "0.4.20"
 

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -20,8 +20,8 @@ starknet = { workspace = true }
 # Other
 eyre = { workspace = true }
 tracing = { workspace = true }
-rustc-hash = "1.1.0"
 thiserror = { workspace = true }
+hashbrown = {workspace = true}
 
 [dev-dependencies]
 lazy_static = { workspace = true }

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -21,7 +21,7 @@ starknet = { workspace = true }
 eyre = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-hashbrown = {workspace = true}
+hashbrown = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }

--- a/crates/sequencer/src/serde.rs
+++ b/crates/sequencer/src/serde.rs
@@ -60,7 +60,6 @@ pub struct SerializableState {
 
 mod serialize_contract_storage {
     use crate::state::ContractStorageKey;
-    use hashbrown::hash_map::DefaultHashBuilder;
     use hashbrown::HashMap;
     use serde::de::{Deserializer, MapAccess, Visitor};
     use serde::ser::{SerializeMap, Serializer};
@@ -115,9 +114,8 @@ mod serialize_contract_storage {
         where
             M: MapAccess<'de>,
         {
-            let mut map = HashMap::with_capacity_and_hasher(
-                access.size_hint().unwrap_or(0),
-                DefaultHashBuilder::default(),
+            let mut map = HashMap::with_capacity(
+                access.size_hint().unwrap_or(0)
             );
 
             // While there are entries remaining in the input, add them

--- a/crates/sequencer/src/serde.rs
+++ b/crates/sequencer/src/serde.rs
@@ -114,9 +114,7 @@ mod serialize_contract_storage {
         where
             M: MapAccess<'de>,
         {
-            let mut map = HashMap::with_capacity(
-                access.size_hint().unwrap_or(0)
-            );
+            let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
 
             // While there are entries remaining in the input, add them
             // into our map.

--- a/crates/sequencer/src/serde.rs
+++ b/crates/sequencer/src/serde.rs
@@ -1,7 +1,7 @@
 use std::{fs, io, path::Path};
 
 use blockifier::execution::contract_class::ContractClass;
-use rustc_hash::FxHashMap;
+use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 use starknet_api::{
     core::{ClassHash, CompiledClassHash, ContractAddress, Nonce},
@@ -50,26 +50,25 @@ pub enum SerializationError {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct SerializableState {
-    pub classes: FxHashMap<ClassHash, ContractClass>,
-    pub compiled_classes_hash: FxHashMap<ClassHash, CompiledClassHash>,
-    pub contracts: FxHashMap<ContractAddress, ClassHash>,
+    pub classes: HashMap<ClassHash, ContractClass>,
+    pub compiled_classes_hash: HashMap<ClassHash, CompiledClassHash>,
+    pub contracts: HashMap<ContractAddress, ClassHash>,
     #[serde(with = "serialize_contract_storage")]
-    pub storage: FxHashMap<ContractStorageKey, StarkFelt>,
-    pub nonces: FxHashMap<ContractAddress, Nonce>,
+    pub storage: HashMap<ContractStorageKey, StarkFelt>,
+    pub nonces: HashMap<ContractAddress, Nonce>,
 }
 
 mod serialize_contract_storage {
-    use rustc_hash::{FxHashMap, FxHasher};
+    use crate::state::ContractStorageKey;
+    use hashbrown::hash_map::DefaultHashBuilder;
+    use hashbrown::HashMap;
     use serde::de::{Deserializer, MapAccess, Visitor};
     use serde::ser::{SerializeMap, Serializer};
     use starknet_api::hash::StarkFelt;
     use std::fmt;
-    use std::hash::BuildHasherDefault;
-
-    use crate::state::ContractStorageKey;
 
     pub fn serialize<S>(
-        map: &FxHashMap<ContractStorageKey, StarkFelt>,
+        map: &HashMap<ContractStorageKey, StarkFelt>,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
@@ -91,7 +90,7 @@ mod serialize_contract_storage {
 
     pub fn deserialize<'de, D>(
         deserializer: D,
-    ) -> Result<FxHashMap<ContractStorageKey, StarkFelt>, D::Error>
+    ) -> Result<HashMap<ContractStorageKey, StarkFelt>, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -102,7 +101,7 @@ mod serialize_contract_storage {
 
     impl<'de> Visitor<'de> for MapContractStorageKeyVisitor {
         // The type that our Visitor is going to produce.
-        type Value = FxHashMap<ContractStorageKey, StarkFelt>;
+        type Value = HashMap<ContractStorageKey, StarkFelt>;
 
         // Format a message stating what data this Visitor expects to receive.
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -116,9 +115,9 @@ mod serialize_contract_storage {
         where
             M: MapAccess<'de>,
         {
-            let mut map = FxHashMap::with_capacity_and_hasher(
+            let mut map = HashMap::with_capacity_and_hasher(
                 access.size_hint().unwrap_or(0),
-                BuildHasherDefault::<FxHasher>::default(),
+                DefaultHashBuilder::default(),
             );
 
             // While there are entries remaining in the input, add them

--- a/crates/sequencer/src/state.rs
+++ b/crates/sequencer/src/state.rs
@@ -4,7 +4,7 @@ use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{
     State as BlockifierState, StateReader as BlockifierStateReader, StateResult,
 };
-use rustc_hash::FxHashMap;
+use hashbrown::HashMap;
 use starknet_api::core::CompiledClassHash;
 use starknet_api::state::StorageKey;
 use starknet_api::{
@@ -20,18 +20,18 @@ use crate::serde::SerializableState;
 pub type ContractStorageKey = (ContractAddress, StorageKey);
 
 /// Generic state structure for the sequencer.
-/// The use of `FxHashMap` allows for a better performance.
+/// The use of `HashMap` implementation from hashbrown allows for a better performance.
 /// This hash map is used by rustc. It uses a non cryptographic hash function
 /// which is faster than the default hash function. Think about changing
 /// if the test sequencer is used for tests outside of ef-tests.
 /// See [rustc-hash](https://crates.io/crates/rustc-hash) for more information.
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct State {
-    classes: FxHashMap<ClassHash, ContractClass>,
-    compiled_class_hashes: FxHashMap<ClassHash, CompiledClassHash>,
-    contracts: FxHashMap<ContractAddress, ClassHash>,
-    storage: FxHashMap<ContractStorageKey, StarkFelt>,
-    nonces: FxHashMap<ContractAddress, Nonce>,
+    classes: HashMap<ClassHash, ContractClass>,
+    compiled_class_hashes: HashMap<ClassHash, CompiledClassHash>,
+    contracts: HashMap<ContractAddress, ClassHash>,
+    storage: HashMap<ContractStorageKey, StarkFelt>,
+    nonces: HashMap<ContractAddress, Nonce>,
 }
 
 impl From<State> for SerializableState {

--- a/crates/sequencer/src/state.rs
+++ b/crates/sequencer/src/state.rs
@@ -21,10 +21,7 @@ pub type ContractStorageKey = (ContractAddress, StorageKey);
 
 /// Generic state structure for the sequencer.
 /// The use of `HashMap` implementation from hashbrown allows for a better performance.
-/// This hash map is used by rustc. It uses a non cryptographic hash function
-/// which is faster than the default hash function. Think about changing
-/// if the test sequencer is used for tests outside of ef-tests.
-/// See [rustc-hash](https://crates.io/crates/rustc-hash) for more information.
+/// See [Performance](https://github.com/rust-lang/hashbrown?tab=readme-ov-file#performance)
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct State {
     classes: HashMap<ClassHash, ContractClass>,


### PR DESCRIPTION
# Pull Request type

This Pull Request updates the sequencer crate to use the hashbrown crate for hash maps instead of rustc_hash.

Time spent on this PR: one hour

Resolves: #686

<!-- Please try to limit your pull request to one type;
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
