### PR TITLE
chore: bump versioned_constants.json to 0.13.2

### DIFF
--- a/crates/ef-testing/src/evm_sequencer/sequencer/resources/versioned_constants.json
+++ b/crates/ef-testing/src/evm_sequencer/sequencer/resources/versioned_constants.json
@@ -1,608 +1,563 @@
 {
   "tx_event_limits": {
-      "max_data_length": 300,
-      "max_keys_length": 50,
-      "max_n_emitted_events": 1000
+    "max_data_length": 300,
+    "max_keys_length": 50,
+    "max_n_emitted_events": 1000
   },
   "gateway": {
-      "max_calldata_length": 5000,
-      "max_contract_bytecode_size": 81920
+    "max_calldata_length": 5000,
+    "max_contract_bytecode_size": 81920
   },
   "invoke_tx_max_n_steps": 50000000,
   "l2_resource_gas_costs": {
-      "gas_per_data_felt": [
-          128,
-          1000
-      ],
-      "event_key_factor": [
-          2,
-          1
-      ],
-      "gas_per_code_byte": [
-          875,
-          1000
-      ]
+    "gas_per_data_felt": [128, 1000],
+    "event_key_factor": [2, 1],
+    "gas_per_code_byte": [875, 1000]
   },
   "disable_cairo0_redeclaration": true,
   "max_recursion_depth": 50,
   "segment_arena_cells": false,
   "os_constants": {
-      "block_hash_contract_address": 1,
-      "call_contract_gas_cost": {
-          "entry_point_gas_cost": 1,
-          "step_gas_cost": 10,
-          "syscall_base_gas_cost": 1
-      },
-      "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
-      "default_entry_point_selector": 0,
-      "deploy_gas_cost": {
-          "entry_point_gas_cost": 1,
-          "step_gas_cost": 200,
-          "syscall_base_gas_cost": 1
-      },
-      "emit_event_gas_cost": {
-          "step_gas_cost": 10,
-          "syscall_base_gas_cost": 1
-      },
-      "entry_point_gas_cost": {
-          "entry_point_initial_budget": 1,
-          "step_gas_cost": 500
-      },
-      "entry_point_initial_budget": {
-          "step_gas_cost": 100
-      },
-      "entry_point_type_constructor": 2,
-      "entry_point_type_external": 0,
-      "entry_point_type_l1_handler": 1,
-      "error_block_number_out_of_range": "Block number out of range",
-      "error_invalid_input_len": "Invalid input length",
-      "error_invalid_argument": "Invalid argument",
-      "error_out_of_gas": "Out of gas",
-      "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-      "fee_transfer_gas_cost": {
-          "entry_point_gas_cost": 1,
-          "step_gas_cost": 100
-      },
-      "get_block_hash_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "get_execution_info_gas_cost": {
-          "step_gas_cost": 10,
-          "syscall_base_gas_cost": 1
-      },
-      "initial_gas_cost": {
-          "step_gas_cost": 100000000
-      },
-      "keccak_gas_cost": {
-          "syscall_base_gas_cost": 1
-      },
-      "keccak_round_cost_gas_cost": 180000,
-      "l1_gas": "L1_GAS",
-      "l1_gas_index": 0,
-      "l1_handler_version": 0,
-      "l2_gas": "L2_GAS",
-      "l2_gas_index": 1,
-      "library_call_gas_cost": {
-          "call_contract_gas_cost": 1
-      },
-      "sha256_process_block_gas_cost": {
-          "step_gas_cost": 1852,
-          "range_check_gas_cost": 65,
-          "bitwise_builtin_gas_cost": 1115,
-          "syscall_base_gas_cost": 1
-      },
-      "memory_hole_gas_cost": 10,
-      "nop_entry_point_offset": -1,
-      "range_check_gas_cost": 70,
-      "bitwise_builtin_gas_cost": 594,
-      "replace_class_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "secp256k1_add_gas_cost": {
-          "range_check_gas_cost": 29,
-          "step_gas_cost": 406
-      },
-      "secp256k1_get_point_from_x_gas_cost": {
-          "memory_hole_gas_cost": 20,
-          "range_check_gas_cost": 30,
-          "step_gas_cost": 391
-      },
-      "secp256k1_get_xy_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 11,
-          "step_gas_cost": 239
-      },
-      "secp256k1_mul_gas_cost": {
-          "memory_hole_gas_cost": 2,
-          "range_check_gas_cost": 7045,
-          "step_gas_cost": 76501
-      },
-      "secp256k1_new_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 35,
-          "step_gas_cost": 475
-      },
-      "secp256r1_add_gas_cost": {
-          "range_check_gas_cost": 57,
-          "step_gas_cost": 589
-      },
-      "secp256r1_get_point_from_x_gas_cost": {
-          "memory_hole_gas_cost": 20,
-          "range_check_gas_cost": 44,
-          "step_gas_cost": 510
-      },
-      "secp256r1_get_xy_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 11,
-          "step_gas_cost": 241
-      },
-      "secp256r1_mul_gas_cost": {
-          "memory_hole_gas_cost": 2,
-          "range_check_gas_cost": 13961,
-          "step_gas_cost": 125340
-      },
-      "secp256r1_new_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 49,
-          "step_gas_cost": 594
-      },
-      "send_message_to_l1_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "sierra_array_len_bound": 4294967296,
-      "step_gas_cost": 100,
-      "storage_read_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "storage_write_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "stored_block_hash_buffer": 10,
-      "syscall_base_gas_cost": {
-          "step_gas_cost": 100
-      },
-      "transaction_gas_cost": {
-          "entry_point_gas_cost": 2,
-          "fee_transfer_gas_cost": 1,
-          "step_gas_cost": 100
-      },
-      "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-      "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
-      "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
-      "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
-      "validate_rounding_consts": {
-          "validate_block_number_rounding": 100,
-          "validate_timestamp_rounding": 3600
-      },
-      "validated": "VALID"
+    "block_hash_contract_address": 1,
+    "call_contract_gas_cost": {
+      "entry_point_gas_cost": 1,
+      "step_gas_cost": 10,
+      "syscall_base_gas_cost": 1
+    },
+    "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+    "default_entry_point_selector": 0,
+    "deploy_gas_cost": {
+      "entry_point_gas_cost": 1,
+      "step_gas_cost": 200,
+      "syscall_base_gas_cost": 1
+    },
+    "emit_event_gas_cost": {
+      "step_gas_cost": 10,
+      "syscall_base_gas_cost": 1
+    },
+    "entry_point_gas_cost": {
+      "entry_point_initial_budget": 1,
+      "step_gas_cost": 500
+    },
+    "entry_point_initial_budget": {
+      "step_gas_cost": 100
+    },
+    "entry_point_type_constructor": 2,
+    "entry_point_type_external": 0,
+    "entry_point_type_l1_handler": 1,
+    "error_block_number_out_of_range": "Block number out of range",
+    "error_invalid_input_len": "Invalid input length",
+    "error_invalid_argument": "Invalid argument",
+    "error_out_of_gas": "Out of gas",
+    "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+    "fee_transfer_gas_cost": {
+      "entry_point_gas_cost": 1,
+      "step_gas_cost": 100
+    },
+    "get_block_hash_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "get_execution_info_gas_cost": {
+      "step_gas_cost": 10,
+      "syscall_base_gas_cost": 1
+    },
+    "initial_gas_cost": {
+      "step_gas_cost": 100000000
+    },
+    "keccak_gas_cost": {
+      "syscall_base_gas_cost": 1
+    },
+    "keccak_round_cost_gas_cost": 180000,
+    "l1_gas": "L1_GAS",
+    "l1_gas_index": 0,
+    "l1_handler_version": 0,
+    "l2_gas": "L2_GAS",
+    "l2_gas_index": 1,
+    "library_call_gas_cost": {
+      "call_contract_gas_cost": 1
+    },
+    "sha256_process_block_gas_cost": {
+      "step_gas_cost": 1852,
+      "range_check_gas_cost": 65,
+      "bitwise_builtin_gas_cost": 1115,
+      "syscall_base_gas_cost": 1
+    },
+    "memory_hole_gas_cost": 10,
+    "nop_entry_point_offset": -1,
+    "range_check_gas_cost": 70,
+    "bitwise_builtin_gas_cost": 594,
+    "replace_class_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "secp256k1_add_gas_cost": {
+      "range_check_gas_cost": 29,
+      "step_gas_cost": 406
+    },
+    "secp256k1_get_point_from_x_gas_cost": {
+      "memory_hole_gas_cost": 20,
+      "range_check_gas_cost": 30,
+      "step_gas_cost": 391
+    },
+    "secp256k1_get_xy_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 11,
+      "step_gas_cost": 239
+    },
+    "secp256k1_mul_gas_cost": {
+      "memory_hole_gas_cost": 2,
+      "range_check_gas_cost": 7045,
+      "step_gas_cost": 76501
+    },
+    "secp256k1_new_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 35,
+      "step_gas_cost": 475
+    },
+    "secp256r1_add_gas_cost": {
+      "range_check_gas_cost": 57,
+      "step_gas_cost": 589
+    },
+    "secp256r1_get_point_from_x_gas_cost": {
+      "memory_hole_gas_cost": 20,
+      "range_check_gas_cost": 44,
+      "step_gas_cost": 510
+    },
+    "secp256r1_get_xy_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 11,
+      "step_gas_cost": 241
+    },
+    "secp256r1_mul_gas_cost": {
+      "memory_hole_gas_cost": 2,
+      "range_check_gas_cost": 13961,
+      "step_gas_cost": 125340
+    },
+    "secp256r1_new_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 49,
+      "step_gas_cost": 594
+    },
+    "send_message_to_l1_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "sierra_array_len_bound": 4294967296,
+    "step_gas_cost": 100,
+    "storage_read_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "storage_write_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "stored_block_hash_buffer": 10,
+    "syscall_base_gas_cost": {
+      "step_gas_cost": 100
+    },
+    "transaction_gas_cost": {
+      "entry_point_gas_cost": 2,
+      "fee_transfer_gas_cost": 1,
+      "step_gas_cost": 100
+    },
+    "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+    "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+    "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+    "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+    "validate_rounding_consts": {
+      "validate_block_number_rounding": 100,
+      "validate_timestamp_rounding": 3600
+    },
+    "validated": "VALID"
   },
   "os_resources": {
-      "execute_syscalls": {
-          "CallContract": {
-              "n_steps": 827,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "DelegateCall": {
-              "n_steps": 713,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 19
-              },
-              "n_memory_holes": 0
-          },
-          "DelegateL1Handler": {
-              "n_steps": 692,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "Deploy": {
-              "n_steps": 1097,
-              "builtin_instance_counter": {
-                  "pedersen_builtin": 7,
-                  "range_check_builtin": 18
-              },
-              "n_memory_holes": 0
-          },
-          "EmitEvent": {
-              "n_steps": 61,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetBlockHash": {
-              "n_steps": 104,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 2
-              },
-              "n_memory_holes": 0
-          },
-          "GetBlockNumber": {
-              "n_steps": 40,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "GetBlockTimestamp": {
-              "n_steps": 38,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "GetCallerAddress": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetContractAddress": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetExecutionInfo": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetSequencerAddress": {
-              "n_steps": 34,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "GetTxInfo": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetTxSignature": {
-              "n_steps": 44,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "Keccak": {
-              "n_steps": 381,
-              "builtin_instance_counter": {
-                  "bitwise_builtin": 6,
-                  "keccak_builtin": 1,
-                  "range_check_builtin": 56
-              },
-              "n_memory_holes": 0
-          },
-          "LibraryCall": {
-              "n_steps": 818,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "LibraryCallL1Handler": {
-              "n_steps": 659,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "ReplaceClass": {
-              "n_steps": 98,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1Add": {
-              "n_steps": 410,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 29
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1GetPointFromX": {
-              "n_steps": 395,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 30
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1GetXy": {
-              "n_steps": 207,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 11
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1Mul": {
-              "n_steps": 76505,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 7045
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1New": {
-              "n_steps": 461,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 35
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1Add": {
-              "n_steps": 593,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 57
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1GetPointFromX": {
-              "n_steps": 514,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 44
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1GetXy": {
-              "n_steps": 209,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 11
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1Mul": {
-              "n_steps": 125344,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 13961
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1New": {
-              "n_steps": 580,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 49
-              },
-              "n_memory_holes": 0
-          },
-          "SendMessageToL1": {
-              "n_steps": 141,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "Sha256ProcessBlock": {
-              "n_steps": 1855,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 65,
-                  "bitwise_builtin": 1115
-              },
-              "n_memory_holes": 0
-          },
-          "StorageRead": {
-              "n_steps": 87,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "StorageWrite": {
-              "n_steps": 89,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          }
+    "execute_syscalls": {
+      "CallContract": {
+        "n_steps": 827,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
       },
-      "execute_txs_inner": {
-          "Declare": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 2973,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 16,
-                          "range_check_builtin": 53
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 0,
-                      "builtin_instance_counter": {},
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 3079,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 4,
-                          "range_check_builtin": 58,
-                          "poseidon_builtin": 10
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 0,
-                      "builtin_instance_counter": {},
-                      "n_memory_holes": 0
-                  }
-              }
-          },
-          "DeployAccount": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 4015,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 23,
-                          "range_check_builtin": 72
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 21,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 2
-                      },
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 4137,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 11,
-                          "range_check_builtin": 77,
-                          "poseidon_builtin": 10
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 21,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 2
-                      },
-                      "n_memory_holes": 0
-                  }
-              }
-          },
-          "InvokeFunction": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 3763,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 14,
-                          "range_check_builtin": 69
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 8,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 3904,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 4,
-                          "range_check_builtin": 74,
-                          "poseidon_builtin": 11
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 8,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              }
-          },
-          "L1Handler": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 1233,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 11,
-                          "range_check_builtin": 16
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 13,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 0,
-                      "builtin_instance_counter": {},
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 13,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              }
-          }
+      "DelegateCall": {
+        "n_steps": 713,
+        "builtin_instance_counter": {
+          "range_check_builtin": 19
+        },
+        "n_memory_holes": 0
       },
-      "compute_os_kzg_commitment_info": {
-          "n_steps": 113,
-          "builtin_instance_counter": {
-              "range_check_builtin": 17
-          },
-          "n_memory_holes": 0
+      "DelegateL1Handler": {
+        "n_steps": 692,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "Deploy": {
+        "n_steps": 1097,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 7,
+          "range_check_builtin": 18
+        },
+        "n_memory_holes": 0
+      },
+      "EmitEvent": {
+        "n_steps": 61,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetBlockHash": {
+        "n_steps": 104,
+        "builtin_instance_counter": {
+          "range_check_builtin": 2
+        },
+        "n_memory_holes": 0
+      },
+      "GetBlockNumber": {
+        "n_steps": 40,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "GetBlockTimestamp": {
+        "n_steps": 38,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "GetCallerAddress": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetContractAddress": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetExecutionInfo": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetSequencerAddress": {
+        "n_steps": 34,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "GetTxInfo": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetTxSignature": {
+        "n_steps": 44,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "Keccak": {
+        "n_steps": 381,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 6,
+          "keccak_builtin": 1,
+          "range_check_builtin": 56
+        },
+        "n_memory_holes": 0
+      },
+      "LibraryCall": {
+        "n_steps": 818,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "LibraryCallL1Handler": {
+        "n_steps": 659,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "ReplaceClass": {
+        "n_steps": 98,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1Add": {
+        "n_steps": 410,
+        "builtin_instance_counter": {
+          "range_check_builtin": 29
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1GetPointFromX": {
+        "n_steps": 395,
+        "builtin_instance_counter": {
+          "range_check_builtin": 30
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1GetXy": {
+        "n_steps": 207,
+        "builtin_instance_counter": {
+          "range_check_builtin": 11
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1Mul": {
+        "n_steps": 76505,
+        "builtin_instance_counter": {
+          "range_check_builtin": 7045
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1New": {
+        "n_steps": 461,
+        "builtin_instance_counter": {
+          "range_check_builtin": 35
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1Add": {
+        "n_steps": 593,
+        "builtin_instance_counter": {
+          "range_check_builtin": 57
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1GetPointFromX": {
+        "n_steps": 514,
+        "builtin_instance_counter": {
+          "range_check_builtin": 44
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1GetXy": {
+        "n_steps": 209,
+        "builtin_instance_counter": {
+          "range_check_builtin": 11
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1Mul": {
+        "n_steps": 125344,
+        "builtin_instance_counter": {
+          "range_check_builtin": 13961
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1New": {
+        "n_steps": 580,
+        "builtin_instance_counter": {
+          "range_check_builtin": 49
+        },
+        "n_memory_holes": 0
+      },
+      "SendMessageToL1": {
+        "n_steps": 141,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "Sha256ProcessBlock": {
+        "n_steps": 1855,
+        "builtin_instance_counter": {
+          "range_check_builtin": 65,
+          "bitwise_builtin": 1115
+        },
+        "n_memory_holes": 0
+      },
+      "StorageRead": {
+        "n_steps": 87,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "StorageWrite": {
+        "n_steps": 89,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
       }
+    },
+    "execute_txs_inner": {
+      "Declare": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 2973,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 16,
+              "range_check_builtin": 53
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 0,
+            "builtin_instance_counter": {},
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 3079,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 4,
+              "range_check_builtin": 58,
+              "poseidon_builtin": 10
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 0,
+            "builtin_instance_counter": {},
+            "n_memory_holes": 0
+          }
+        }
+      },
+      "DeployAccount": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 4015,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 23,
+              "range_check_builtin": 72
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 21,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 2
+            },
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 4137,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 11,
+              "range_check_builtin": 77,
+              "poseidon_builtin": 10
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 21,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 2
+            },
+            "n_memory_holes": 0
+          }
+        }
+      },
+      "InvokeFunction": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 3763,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 14,
+              "range_check_builtin": 69
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 8,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 3904,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 4,
+              "range_check_builtin": 74,
+              "poseidon_builtin": 11
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 8,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        }
+      },
+      "L1Handler": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 1233,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 11,
+              "range_check_builtin": 16
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 13,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 0,
+            "builtin_instance_counter": {},
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 13,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        }
+      }
+    },
+    "compute_os_kzg_commitment_info": {
+      "n_steps": 113,
+      "builtin_instance_counter": {
+        "range_check_builtin": 17
+      },
+      "n_memory_holes": 0
+    }
   },
   "validate_max_n_steps": 1000000,
   "vm_resource_fee_cost": {
-      "add_mod_builtin": [
-          4,
-          100
-      ],
-      "bitwise_builtin": [
-          16,
-          100
-      ],
-      "ec_op_builtin": [
-          256,
-          100
-      ],
-      "ecdsa_builtin": [
-          512,
-          100
-      ],
-      "keccak_builtin": [
-          512,
-          100
-      ],
-      "mul_mod_builtin": [
-          4,
-          100
-      ],
-      "n_steps": [
-          25,
-          10000
-      ],
-      "output_builtin": [
-          0,
-          1
-      ],
-      "pedersen_builtin": [
-          8,
-          100
-      ],
-      "poseidon_builtin": [
-          8,
-          100
-      ],
-      "range_check_builtin": [
-          4,
-          100
-      ],
-      "range_check96_builtin": [
-          4,
-          100
-      ]
+    "add_mod_builtin": [4, 100],
+    "bitwise_builtin": [16, 100],
+    "ec_op_builtin": [256, 100],
+    "ecdsa_builtin": [512, 100],
+    "keccak_builtin": [512, 100],
+    "mul_mod_builtin": [4, 100],
+    "n_steps": [25, 10000],
+    "output_builtin": [0, 1],
+    "pedersen_builtin": [8, 100],
+    "poseidon_builtin": [8, 100],
+    "range_check_builtin": [4, 100],
+    "range_check96_builtin": [4, 100]
   }
 }

--- a/crates/ef-testing/src/evm_sequencer/sequencer/resources/versioned_constants.json
+++ b/crates/ef-testing/src/evm_sequencer/sequencer/resources/versioned_constants.json
@@ -1,555 +1,608 @@
 {
   "tx_event_limits": {
-    "max_data_length": 300,
-    "max_keys_length": 50,
-    "max_n_emitted_events": 1000
+      "max_data_length": 300,
+      "max_keys_length": 50,
+      "max_n_emitted_events": 1000
   },
   "gateway": {
-    "max_calldata_length": 5000,
-    "max_contract_bytecode_size": 81920
+      "max_calldata_length": 5000,
+      "max_contract_bytecode_size": 81920
   },
   "invoke_tx_max_n_steps": 50000000,
   "l2_resource_gas_costs": {
-    "gas_per_data_felt": [128, 1000],
-    "event_key_factor": [2, 1],
-    "gas_per_code_byte": [32, 1000]
+      "gas_per_data_felt": [
+          128,
+          1000
+      ],
+      "event_key_factor": [
+          2,
+          1
+      ],
+      "gas_per_code_byte": [
+          875,
+          1000
+      ]
   },
+  "disable_cairo0_redeclaration": true,
   "max_recursion_depth": 50,
-  "segment_arena_cells": true,
+  "segment_arena_cells": false,
   "os_constants": {
-    "nop_entry_point_offset": -1,
-    "entry_point_type_external": 0,
-    "entry_point_type_l1_handler": 1,
-    "entry_point_type_constructor": 2,
-    "l1_handler_version": 0,
-    "sierra_array_len_bound": 4294967296,
-    "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
-    "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-    "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
-    "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
-    "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
-    "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-    "default_entry_point_selector": 0,
-    "block_hash_contract_address": 1,
-    "stored_block_hash_buffer": 10,
-    "step_gas_cost": 100,
-    "range_check_gas_cost": 70,
-    "memory_hole_gas_cost": 10,
-    "initial_gas_cost": {
-      "step_gas_cost": 100000000
-    },
-    "entry_point_initial_budget": {
-      "step_gas_cost": 100
-    },
-    "syscall_base_gas_cost": {
-      "step_gas_cost": 100
-    },
-    "entry_point_gas_cost": {
-      "entry_point_initial_budget": 1,
-      "step_gas_cost": 500
-    },
-    "fee_transfer_gas_cost": {
-      "entry_point_gas_cost": 1,
-      "step_gas_cost": 100
-    },
-    "transaction_gas_cost": {
-      "entry_point_gas_cost": 2,
-      "fee_transfer_gas_cost": 1,
-      "step_gas_cost": 100
-    },
-    "call_contract_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 10,
-      "entry_point_gas_cost": 1
-    },
-    "deploy_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 200,
-      "entry_point_gas_cost": 1
-    },
-    "get_block_hash_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "get_execution_info_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 10
-    },
-    "library_call_gas_cost": {
-      "call_contract_gas_cost": 1
-    },
-    "replace_class_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "storage_read_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "storage_write_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "emit_event_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 10
-    },
-    "send_message_to_l1_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "secp256k1_add_gas_cost": {
-      "step_gas_cost": 406,
-      "range_check_gas_cost": 29
-    },
-    "secp256k1_get_point_from_x_gas_cost": {
-      "step_gas_cost": 391,
-      "range_check_gas_cost": 30,
-      "memory_hole_gas_cost": 20
-    },
-    "secp256k1_get_xy_gas_cost": {
-      "step_gas_cost": 239,
-      "range_check_gas_cost": 11,
-      "memory_hole_gas_cost": 40
-    },
-    "secp256k1_mul_gas_cost": {
-      "step_gas_cost": 76501,
-      "range_check_gas_cost": 7045,
-      "memory_hole_gas_cost": 2
-    },
-    "secp256k1_new_gas_cost": {
-      "step_gas_cost": 475,
-      "range_check_gas_cost": 35,
-      "memory_hole_gas_cost": 40
-    },
-    "secp256r1_add_gas_cost": {
-      "step_gas_cost": 589,
-      "range_check_gas_cost": 57
-    },
-    "secp256r1_get_point_from_x_gas_cost": {
-      "step_gas_cost": 510,
-      "range_check_gas_cost": 44,
-      "memory_hole_gas_cost": 20
-    },
-    "secp256r1_get_xy_gas_cost": {
-      "step_gas_cost": 241,
-      "range_check_gas_cost": 11,
-      "memory_hole_gas_cost": 40
-    },
-    "secp256r1_mul_gas_cost": {
-      "step_gas_cost": 125340,
-      "range_check_gas_cost": 13961,
-      "memory_hole_gas_cost": 2
-    },
-    "secp256r1_new_gas_cost": {
-      "step_gas_cost": 594,
-      "range_check_gas_cost": 49,
-      "memory_hole_gas_cost": 40
-    },
-    "keccak_gas_cost": {
-      "syscall_base_gas_cost": 1
-    },
-    "keccak_round_cost_gas_cost": 180000,
-    "sha256_process_block_gas_cost": {
-      "step_gas_cost": 0,
-      "range_check_gas_cost": 0,
-      "syscall_base_gas_cost": 0
-    },
-    "error_block_number_out_of_range": "Block number out of range",
-    "error_out_of_gas": "Out of gas",
-    "error_invalid_input_len": "Invalid input length",
-    "error_invalid_argument": "Invalid argument",
-    "validated": "VALID",
-    "l1_gas": "L1_GAS",
-    "l2_gas": "L2_GAS",
-    "l1_gas_index": 0,
-    "l2_gas_index": 1,
-    "validate_rounding_consts": {
-      "validate_block_number_rounding": 100,
-      "validate_timestamp_rounding": 3600
-    }
+      "block_hash_contract_address": 1,
+      "call_contract_gas_cost": {
+          "entry_point_gas_cost": 1,
+          "step_gas_cost": 10,
+          "syscall_base_gas_cost": 1
+      },
+      "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+      "default_entry_point_selector": 0,
+      "deploy_gas_cost": {
+          "entry_point_gas_cost": 1,
+          "step_gas_cost": 200,
+          "syscall_base_gas_cost": 1
+      },
+      "emit_event_gas_cost": {
+          "step_gas_cost": 10,
+          "syscall_base_gas_cost": 1
+      },
+      "entry_point_gas_cost": {
+          "entry_point_initial_budget": 1,
+          "step_gas_cost": 500
+      },
+      "entry_point_initial_budget": {
+          "step_gas_cost": 100
+      },
+      "entry_point_type_constructor": 2,
+      "entry_point_type_external": 0,
+      "entry_point_type_l1_handler": 1,
+      "error_block_number_out_of_range": "Block number out of range",
+      "error_invalid_input_len": "Invalid input length",
+      "error_invalid_argument": "Invalid argument",
+      "error_out_of_gas": "Out of gas",
+      "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "fee_transfer_gas_cost": {
+          "entry_point_gas_cost": 1,
+          "step_gas_cost": 100
+      },
+      "get_block_hash_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "get_execution_info_gas_cost": {
+          "step_gas_cost": 10,
+          "syscall_base_gas_cost": 1
+      },
+      "initial_gas_cost": {
+          "step_gas_cost": 100000000
+      },
+      "keccak_gas_cost": {
+          "syscall_base_gas_cost": 1
+      },
+      "keccak_round_cost_gas_cost": 180000,
+      "l1_gas": "L1_GAS",
+      "l1_gas_index": 0,
+      "l1_handler_version": 0,
+      "l2_gas": "L2_GAS",
+      "l2_gas_index": 1,
+      "library_call_gas_cost": {
+          "call_contract_gas_cost": 1
+      },
+      "sha256_process_block_gas_cost": {
+          "step_gas_cost": 1852,
+          "range_check_gas_cost": 65,
+          "bitwise_builtin_gas_cost": 1115,
+          "syscall_base_gas_cost": 1
+      },
+      "memory_hole_gas_cost": 10,
+      "nop_entry_point_offset": -1,
+      "range_check_gas_cost": 70,
+      "bitwise_builtin_gas_cost": 594,
+      "replace_class_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "secp256k1_add_gas_cost": {
+          "range_check_gas_cost": 29,
+          "step_gas_cost": 406
+      },
+      "secp256k1_get_point_from_x_gas_cost": {
+          "memory_hole_gas_cost": 20,
+          "range_check_gas_cost": 30,
+          "step_gas_cost": 391
+      },
+      "secp256k1_get_xy_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 11,
+          "step_gas_cost": 239
+      },
+      "secp256k1_mul_gas_cost": {
+          "memory_hole_gas_cost": 2,
+          "range_check_gas_cost": 7045,
+          "step_gas_cost": 76501
+      },
+      "secp256k1_new_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 35,
+          "step_gas_cost": 475
+      },
+      "secp256r1_add_gas_cost": {
+          "range_check_gas_cost": 57,
+          "step_gas_cost": 589
+      },
+      "secp256r1_get_point_from_x_gas_cost": {
+          "memory_hole_gas_cost": 20,
+          "range_check_gas_cost": 44,
+          "step_gas_cost": 510
+      },
+      "secp256r1_get_xy_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 11,
+          "step_gas_cost": 241
+      },
+      "secp256r1_mul_gas_cost": {
+          "memory_hole_gas_cost": 2,
+          "range_check_gas_cost": 13961,
+          "step_gas_cost": 125340
+      },
+      "secp256r1_new_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 49,
+          "step_gas_cost": 594
+      },
+      "send_message_to_l1_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "sierra_array_len_bound": 4294967296,
+      "step_gas_cost": 100,
+      "storage_read_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "storage_write_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "stored_block_hash_buffer": 10,
+      "syscall_base_gas_cost": {
+          "step_gas_cost": 100
+      },
+      "transaction_gas_cost": {
+          "entry_point_gas_cost": 2,
+          "fee_transfer_gas_cost": 1,
+          "step_gas_cost": 100
+      },
+      "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+      "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+      "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+      "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+      "validate_rounding_consts": {
+          "validate_block_number_rounding": 100,
+          "validate_timestamp_rounding": 3600
+      },
+      "validated": "VALID"
   },
   "os_resources": {
-    "execute_syscalls": {
-      "CallContract": {
-        "n_steps": 760,
-        "builtin_instance_counter": {
-          "range_check_builtin": 20
-        },
-        "n_memory_holes": 0
-      },
-      "DelegateCall": {
-        "n_steps": 713,
-        "builtin_instance_counter": {
-          "range_check_builtin": 19
-        },
-        "n_memory_holes": 0
-      },
-      "DelegateL1Handler": {
-        "n_steps": 692,
-        "builtin_instance_counter": {
-          "range_check_builtin": 15
-        },
-        "n_memory_holes": 0
-      },
-      "Deploy": {
-        "n_steps": 1012,
-        "builtin_instance_counter": {
-          "pedersen_builtin": 7,
-          "range_check_builtin": 19
-        },
-        "n_memory_holes": 0
-      },
-      "EmitEvent": {
-        "n_steps": 61,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetBlockHash": {
-        "n_steps": 104,
-        "builtin_instance_counter": {
-          "range_check_builtin": 2
-        },
-        "n_memory_holes": 0
-      },
-      "GetBlockNumber": {
-        "n_steps": 40,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "GetBlockTimestamp": {
-        "n_steps": 38,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "GetCallerAddress": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetContractAddress": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetExecutionInfo": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetSequencerAddress": {
-        "n_steps": 34,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "GetTxInfo": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetTxSignature": {
-        "n_steps": 44,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "Keccak": {
-        "n_steps": 381,
-        "builtin_instance_counter": {
-          "bitwise_builtin": 6,
-          "keccak_builtin": 1,
-          "range_check_builtin": 56
-        },
-        "n_memory_holes": 0
-      },
-      "LibraryCall": {
-        "n_steps": 751,
-        "builtin_instance_counter": {
-          "range_check_builtin": 20
-        },
-        "n_memory_holes": 0
-      },
-      "LibraryCallL1Handler": {
-        "n_steps": 659,
-        "builtin_instance_counter": {
-          "range_check_builtin": 15
-        },
-        "n_memory_holes": 0
-      },
-      "ReplaceClass": {
-        "n_steps": 98,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1Add": {
-        "n_steps": 408,
-        "builtin_instance_counter": {
-          "range_check_builtin": 29
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1GetPointFromX": {
-        "n_steps": 393,
-        "builtin_instance_counter": {
-          "range_check_builtin": 30
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1GetXy": {
-        "n_steps": 205,
-        "builtin_instance_counter": {
-          "range_check_builtin": 11
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1Mul": {
-        "n_steps": 76503,
-        "builtin_instance_counter": {
-          "range_check_builtin": 7045
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1New": {
-        "n_steps": 459,
-        "builtin_instance_counter": {
-          "range_check_builtin": 35
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1Add": {
-        "n_steps": 591,
-        "builtin_instance_counter": {
-          "range_check_builtin": 57
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1GetPointFromX": {
-        "n_steps": 512,
-        "builtin_instance_counter": {
-          "range_check_builtin": 44
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1GetXy": {
-        "n_steps": 207,
-        "builtin_instance_counter": {
-          "range_check_builtin": 11
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1Mul": {
-        "n_steps": 125342,
-        "builtin_instance_counter": {
-          "range_check_builtin": 13961
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1New": {
-        "n_steps": 578,
-        "builtin_instance_counter": {
-          "range_check_builtin": 49
-        },
-        "n_memory_holes": 0
-      },
-      "SendMessageToL1": {
-        "n_steps": 139,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "Sha256ProcessBlock": {
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0,
-        "n_steps": 0
-      },
-      "StorageRead": {
-        "n_steps": 87,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "StorageWrite": {
-        "n_steps": 89,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      }
-    },
-    "execute_txs_inner": {
-      "Declare": {
-        "resources": {
-          "constant": {
-            "n_steps": 2839,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 16,
-              "range_check_builtin": 63
-            },
-            "n_memory_holes": 0
+      "execute_syscalls": {
+          "CallContract": {
+              "n_steps": 827,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
           },
-          "calldata_factor": {
-            "n_steps": 0,
-            "builtin_instance_counter": {},
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 2839,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 16,
-              "range_check_builtin": 63
-            },
-            "n_memory_holes": 0
+          "DelegateCall": {
+              "n_steps": 713,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 19
+              },
+              "n_memory_holes": 0
           },
-          "calldata_factor": {
-            "n_steps": 0,
-            "builtin_instance_counter": {},
-            "n_memory_holes": 0
+          "DelegateL1Handler": {
+              "n_steps": 692,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
+          },
+          "Deploy": {
+              "n_steps": 1097,
+              "builtin_instance_counter": {
+                  "pedersen_builtin": 7,
+                  "range_check_builtin": 18
+              },
+              "n_memory_holes": 0
+          },
+          "EmitEvent": {
+              "n_steps": 61,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetBlockHash": {
+              "n_steps": 104,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 2
+              },
+              "n_memory_holes": 0
+          },
+          "GetBlockNumber": {
+              "n_steps": 40,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "GetBlockTimestamp": {
+              "n_steps": 38,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "GetCallerAddress": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetContractAddress": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetExecutionInfo": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetSequencerAddress": {
+              "n_steps": 34,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "GetTxInfo": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetTxSignature": {
+              "n_steps": 44,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "Keccak": {
+              "n_steps": 381,
+              "builtin_instance_counter": {
+                  "bitwise_builtin": 6,
+                  "keccak_builtin": 1,
+                  "range_check_builtin": 56
+              },
+              "n_memory_holes": 0
+          },
+          "LibraryCall": {
+              "n_steps": 818,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
+          },
+          "LibraryCallL1Handler": {
+              "n_steps": 659,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
+          },
+          "ReplaceClass": {
+              "n_steps": 98,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1Add": {
+              "n_steps": 410,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 29
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1GetPointFromX": {
+              "n_steps": 395,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 30
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1GetXy": {
+              "n_steps": 207,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 11
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1Mul": {
+              "n_steps": 76505,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 7045
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1New": {
+              "n_steps": 461,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 35
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1Add": {
+              "n_steps": 593,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 57
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1GetPointFromX": {
+              "n_steps": 514,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 44
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1GetXy": {
+              "n_steps": 209,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 11
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1Mul": {
+              "n_steps": 125344,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 13961
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1New": {
+              "n_steps": 580,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 49
+              },
+              "n_memory_holes": 0
+          },
+          "SendMessageToL1": {
+              "n_steps": 141,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "Sha256ProcessBlock": {
+              "n_steps": 1855,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 65,
+                  "bitwise_builtin": 1115
+              },
+              "n_memory_holes": 0
+          },
+          "StorageRead": {
+              "n_steps": 87,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "StorageWrite": {
+              "n_steps": 89,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
           }
-        }
       },
-      "DeployAccount": {
-        "resources": {
-          "constant": {
-            "n_steps": 3792,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 23,
-              "range_check_builtin": 83
-            },
-            "n_memory_holes": 0
+      "execute_txs_inner": {
+          "Declare": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 2973,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 16,
+                          "range_check_builtin": 53
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 0,
+                      "builtin_instance_counter": {},
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 3079,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 4,
+                          "range_check_builtin": 58,
+                          "poseidon_builtin": 10
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 0,
+                      "builtin_instance_counter": {},
+                      "n_memory_holes": 0
+                  }
+              }
           },
-          "calldata_factor": {
-            "n_steps": 21,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 2
-            },
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 3792,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 23,
-              "range_check_builtin": 83
-            },
-            "n_memory_holes": 0
+          "DeployAccount": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 4015,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 23,
+                          "range_check_builtin": 72
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 21,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 2
+                      },
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 4137,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 11,
+                          "range_check_builtin": 77,
+                          "poseidon_builtin": 10
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 21,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 2
+                      },
+                      "n_memory_holes": 0
+                  }
+              }
           },
-          "calldata_factor": {
-            "n_steps": 21,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 2
-            },
-            "n_memory_holes": 0
+          "InvokeFunction": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 3763,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 14,
+                          "range_check_builtin": 69
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 8,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 3904,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 4,
+                          "range_check_builtin": 74,
+                          "poseidon_builtin": 11
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 8,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              }
+          },
+          "L1Handler": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 1233,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 11,
+                          "range_check_builtin": 16
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 13,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 0,
+                      "builtin_instance_counter": {},
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 13,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              }
           }
-        }
       },
-      "InvokeFunction": {
-        "resources": {
-          "constant": {
-            "n_steps": 3546,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 14,
-              "range_check_builtin": 80
-            },
-            "n_memory_holes": 0
-          },
-          "calldata_factor": {
-            "n_steps": 8,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 3546,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 14,
-              "range_check_builtin": 80
-            },
-            "n_memory_holes": 0
-          },
-          "calldata_factor": {
-            "n_steps": 8,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        }
-      },
-      "L1Handler": {
-        "resources": {
-          "constant": {
-            "n_steps": 1146,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 11,
+      "compute_os_kzg_commitment_info": {
+          "n_steps": 113,
+          "builtin_instance_counter": {
               "range_check_builtin": 17
-            },
-            "n_memory_holes": 0
           },
-          "calldata_factor": {
-            "n_steps": 13,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 1146,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 11,
-              "range_check_builtin": 17
-            },
-            "n_memory_holes": 0
-          },
-          "calldata_factor": {
-            "n_steps": 13,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        }
+          "n_memory_holes": 0
       }
-    },
-    "compute_os_kzg_commitment_info": {
-      "n_steps": 0,
-      "builtin_instance_counter": {},
-      "n_memory_holes": 0
-    }
   },
   "validate_max_n_steps": 1000000,
   "vm_resource_fee_cost": {
-    "add_mod_builtin": [0, 1],
-    "bitwise_builtin": [16, 100],
-    "ec_op_builtin": [256, 100],
-    "ecdsa_builtin": [512, 100],
-    "keccak_builtin": [512, 100],
-    "mul_mod_builtin": [0, 1],
-    "n_steps": [25, 10000],
-    "output_builtin": [0, 1],
-    "pedersen_builtin": [8, 100],
-    "poseidon_builtin": [8, 100],
-    "range_check_builtin": [4, 100],
-    "range_check96_builtin": [0, 1]
+      "add_mod_builtin": [
+          4,
+          100
+      ],
+      "bitwise_builtin": [
+          16,
+          100
+      ],
+      "ec_op_builtin": [
+          256,
+          100
+      ],
+      "ecdsa_builtin": [
+          512,
+          100
+      ],
+      "keccak_builtin": [
+          512,
+          100
+      ],
+      "mul_mod_builtin": [
+          4,
+          100
+      ],
+      "n_steps": [
+          25,
+          10000
+      ],
+      "output_builtin": [
+          0,
+          1
+      ],
+      "pedersen_builtin": [
+          8,
+          100
+      ],
+      "poseidon_builtin": [
+          8,
+          100
+      ],
+      "range_check_builtin": [
+          4,
+          100
+      ],
+      "range_check96_builtin": [
+          4,
+          100
+      ]
   }
 }

--- a/crates/sequencer/src/resources/versioned_constants.json
+++ b/crates/sequencer/src/resources/versioned_constants.json
@@ -1,608 +1,563 @@
 {
   "tx_event_limits": {
-      "max_data_length": 300,
-      "max_keys_length": 50,
-      "max_n_emitted_events": 1000
+    "max_data_length": 300,
+    "max_keys_length": 50,
+    "max_n_emitted_events": 1000
   },
   "gateway": {
-      "max_calldata_length": 5000,
-      "max_contract_bytecode_size": 81920
+    "max_calldata_length": 5000,
+    "max_contract_bytecode_size": 81920
   },
   "invoke_tx_max_n_steps": 50000000,
   "l2_resource_gas_costs": {
-      "gas_per_data_felt": [
-          128,
-          1000
-      ],
-      "event_key_factor": [
-          2,
-          1
-      ],
-      "gas_per_code_byte": [
-          875,
-          1000
-      ]
+    "gas_per_data_felt": [128, 1000],
+    "event_key_factor": [2, 1],
+    "gas_per_code_byte": [875, 1000]
   },
   "disable_cairo0_redeclaration": true,
   "max_recursion_depth": 50,
   "segment_arena_cells": false,
   "os_constants": {
-      "block_hash_contract_address": 1,
-      "call_contract_gas_cost": {
-          "entry_point_gas_cost": 1,
-          "step_gas_cost": 10,
-          "syscall_base_gas_cost": 1
-      },
-      "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
-      "default_entry_point_selector": 0,
-      "deploy_gas_cost": {
-          "entry_point_gas_cost": 1,
-          "step_gas_cost": 200,
-          "syscall_base_gas_cost": 1
-      },
-      "emit_event_gas_cost": {
-          "step_gas_cost": 10,
-          "syscall_base_gas_cost": 1
-      },
-      "entry_point_gas_cost": {
-          "entry_point_initial_budget": 1,
-          "step_gas_cost": 500
-      },
-      "entry_point_initial_budget": {
-          "step_gas_cost": 100
-      },
-      "entry_point_type_constructor": 2,
-      "entry_point_type_external": 0,
-      "entry_point_type_l1_handler": 1,
-      "error_block_number_out_of_range": "Block number out of range",
-      "error_invalid_input_len": "Invalid input length",
-      "error_invalid_argument": "Invalid argument",
-      "error_out_of_gas": "Out of gas",
-      "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-      "fee_transfer_gas_cost": {
-          "entry_point_gas_cost": 1,
-          "step_gas_cost": 100
-      },
-      "get_block_hash_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "get_execution_info_gas_cost": {
-          "step_gas_cost": 10,
-          "syscall_base_gas_cost": 1
-      },
-      "initial_gas_cost": {
-          "step_gas_cost": 100000000
-      },
-      "keccak_gas_cost": {
-          "syscall_base_gas_cost": 1
-      },
-      "keccak_round_cost_gas_cost": 180000,
-      "l1_gas": "L1_GAS",
-      "l1_gas_index": 0,
-      "l1_handler_version": 0,
-      "l2_gas": "L2_GAS",
-      "l2_gas_index": 1,
-      "library_call_gas_cost": {
-          "call_contract_gas_cost": 1
-      },
-      "sha256_process_block_gas_cost": {
-          "step_gas_cost": 1852,
-          "range_check_gas_cost": 65,
-          "bitwise_builtin_gas_cost": 1115,
-          "syscall_base_gas_cost": 1
-      },
-      "memory_hole_gas_cost": 10,
-      "nop_entry_point_offset": -1,
-      "range_check_gas_cost": 70,
-      "bitwise_builtin_gas_cost": 594,
-      "replace_class_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "secp256k1_add_gas_cost": {
-          "range_check_gas_cost": 29,
-          "step_gas_cost": 406
-      },
-      "secp256k1_get_point_from_x_gas_cost": {
-          "memory_hole_gas_cost": 20,
-          "range_check_gas_cost": 30,
-          "step_gas_cost": 391
-      },
-      "secp256k1_get_xy_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 11,
-          "step_gas_cost": 239
-      },
-      "secp256k1_mul_gas_cost": {
-          "memory_hole_gas_cost": 2,
-          "range_check_gas_cost": 7045,
-          "step_gas_cost": 76501
-      },
-      "secp256k1_new_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 35,
-          "step_gas_cost": 475
-      },
-      "secp256r1_add_gas_cost": {
-          "range_check_gas_cost": 57,
-          "step_gas_cost": 589
-      },
-      "secp256r1_get_point_from_x_gas_cost": {
-          "memory_hole_gas_cost": 20,
-          "range_check_gas_cost": 44,
-          "step_gas_cost": 510
-      },
-      "secp256r1_get_xy_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 11,
-          "step_gas_cost": 241
-      },
-      "secp256r1_mul_gas_cost": {
-          "memory_hole_gas_cost": 2,
-          "range_check_gas_cost": 13961,
-          "step_gas_cost": 125340
-      },
-      "secp256r1_new_gas_cost": {
-          "memory_hole_gas_cost": 40,
-          "range_check_gas_cost": 49,
-          "step_gas_cost": 594
-      },
-      "send_message_to_l1_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "sierra_array_len_bound": 4294967296,
-      "step_gas_cost": 100,
-      "storage_read_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "storage_write_gas_cost": {
-          "step_gas_cost": 50,
-          "syscall_base_gas_cost": 1
-      },
-      "stored_block_hash_buffer": 10,
-      "syscall_base_gas_cost": {
-          "step_gas_cost": 100
-      },
-      "transaction_gas_cost": {
-          "entry_point_gas_cost": 2,
-          "fee_transfer_gas_cost": 1,
-          "step_gas_cost": 100
-      },
-      "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-      "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
-      "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
-      "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
-      "validate_rounding_consts": {
-          "validate_block_number_rounding": 100,
-          "validate_timestamp_rounding": 3600
-      },
-      "validated": "VALID"
+    "block_hash_contract_address": 1,
+    "call_contract_gas_cost": {
+      "entry_point_gas_cost": 1,
+      "step_gas_cost": 10,
+      "syscall_base_gas_cost": 1
+    },
+    "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+    "default_entry_point_selector": 0,
+    "deploy_gas_cost": {
+      "entry_point_gas_cost": 1,
+      "step_gas_cost": 200,
+      "syscall_base_gas_cost": 1
+    },
+    "emit_event_gas_cost": {
+      "step_gas_cost": 10,
+      "syscall_base_gas_cost": 1
+    },
+    "entry_point_gas_cost": {
+      "entry_point_initial_budget": 1,
+      "step_gas_cost": 500
+    },
+    "entry_point_initial_budget": {
+      "step_gas_cost": 100
+    },
+    "entry_point_type_constructor": 2,
+    "entry_point_type_external": 0,
+    "entry_point_type_l1_handler": 1,
+    "error_block_number_out_of_range": "Block number out of range",
+    "error_invalid_input_len": "Invalid input length",
+    "error_invalid_argument": "Invalid argument",
+    "error_out_of_gas": "Out of gas",
+    "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+    "fee_transfer_gas_cost": {
+      "entry_point_gas_cost": 1,
+      "step_gas_cost": 100
+    },
+    "get_block_hash_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "get_execution_info_gas_cost": {
+      "step_gas_cost": 10,
+      "syscall_base_gas_cost": 1
+    },
+    "initial_gas_cost": {
+      "step_gas_cost": 100000000
+    },
+    "keccak_gas_cost": {
+      "syscall_base_gas_cost": 1
+    },
+    "keccak_round_cost_gas_cost": 180000,
+    "l1_gas": "L1_GAS",
+    "l1_gas_index": 0,
+    "l1_handler_version": 0,
+    "l2_gas": "L2_GAS",
+    "l2_gas_index": 1,
+    "library_call_gas_cost": {
+      "call_contract_gas_cost": 1
+    },
+    "sha256_process_block_gas_cost": {
+      "step_gas_cost": 1852,
+      "range_check_gas_cost": 65,
+      "bitwise_builtin_gas_cost": 1115,
+      "syscall_base_gas_cost": 1
+    },
+    "memory_hole_gas_cost": 10,
+    "nop_entry_point_offset": -1,
+    "range_check_gas_cost": 70,
+    "bitwise_builtin_gas_cost": 594,
+    "replace_class_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "secp256k1_add_gas_cost": {
+      "range_check_gas_cost": 29,
+      "step_gas_cost": 406
+    },
+    "secp256k1_get_point_from_x_gas_cost": {
+      "memory_hole_gas_cost": 20,
+      "range_check_gas_cost": 30,
+      "step_gas_cost": 391
+    },
+    "secp256k1_get_xy_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 11,
+      "step_gas_cost": 239
+    },
+    "secp256k1_mul_gas_cost": {
+      "memory_hole_gas_cost": 2,
+      "range_check_gas_cost": 7045,
+      "step_gas_cost": 76501
+    },
+    "secp256k1_new_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 35,
+      "step_gas_cost": 475
+    },
+    "secp256r1_add_gas_cost": {
+      "range_check_gas_cost": 57,
+      "step_gas_cost": 589
+    },
+    "secp256r1_get_point_from_x_gas_cost": {
+      "memory_hole_gas_cost": 20,
+      "range_check_gas_cost": 44,
+      "step_gas_cost": 510
+    },
+    "secp256r1_get_xy_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 11,
+      "step_gas_cost": 241
+    },
+    "secp256r1_mul_gas_cost": {
+      "memory_hole_gas_cost": 2,
+      "range_check_gas_cost": 13961,
+      "step_gas_cost": 125340
+    },
+    "secp256r1_new_gas_cost": {
+      "memory_hole_gas_cost": 40,
+      "range_check_gas_cost": 49,
+      "step_gas_cost": 594
+    },
+    "send_message_to_l1_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "sierra_array_len_bound": 4294967296,
+    "step_gas_cost": 100,
+    "storage_read_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "storage_write_gas_cost": {
+      "step_gas_cost": 50,
+      "syscall_base_gas_cost": 1
+    },
+    "stored_block_hash_buffer": 10,
+    "syscall_base_gas_cost": {
+      "step_gas_cost": 100
+    },
+    "transaction_gas_cost": {
+      "entry_point_gas_cost": 2,
+      "fee_transfer_gas_cost": 1,
+      "step_gas_cost": 100
+    },
+    "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+    "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+    "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+    "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+    "validate_rounding_consts": {
+      "validate_block_number_rounding": 100,
+      "validate_timestamp_rounding": 3600
+    },
+    "validated": "VALID"
   },
   "os_resources": {
-      "execute_syscalls": {
-          "CallContract": {
-              "n_steps": 827,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "DelegateCall": {
-              "n_steps": 713,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 19
-              },
-              "n_memory_holes": 0
-          },
-          "DelegateL1Handler": {
-              "n_steps": 692,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "Deploy": {
-              "n_steps": 1097,
-              "builtin_instance_counter": {
-                  "pedersen_builtin": 7,
-                  "range_check_builtin": 18
-              },
-              "n_memory_holes": 0
-          },
-          "EmitEvent": {
-              "n_steps": 61,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetBlockHash": {
-              "n_steps": 104,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 2
-              },
-              "n_memory_holes": 0
-          },
-          "GetBlockNumber": {
-              "n_steps": 40,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "GetBlockTimestamp": {
-              "n_steps": 38,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "GetCallerAddress": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetContractAddress": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetExecutionInfo": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetSequencerAddress": {
-              "n_steps": 34,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "GetTxInfo": {
-              "n_steps": 64,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "GetTxSignature": {
-              "n_steps": 44,
-              "builtin_instance_counter": {},
-              "n_memory_holes": 0
-          },
-          "Keccak": {
-              "n_steps": 381,
-              "builtin_instance_counter": {
-                  "bitwise_builtin": 6,
-                  "keccak_builtin": 1,
-                  "range_check_builtin": 56
-              },
-              "n_memory_holes": 0
-          },
-          "LibraryCall": {
-              "n_steps": 818,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "LibraryCallL1Handler": {
-              "n_steps": 659,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 15
-              },
-              "n_memory_holes": 0
-          },
-          "ReplaceClass": {
-              "n_steps": 98,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1Add": {
-              "n_steps": 410,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 29
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1GetPointFromX": {
-              "n_steps": 395,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 30
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1GetXy": {
-              "n_steps": 207,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 11
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1Mul": {
-              "n_steps": 76505,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 7045
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256k1New": {
-              "n_steps": 461,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 35
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1Add": {
-              "n_steps": 593,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 57
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1GetPointFromX": {
-              "n_steps": 514,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 44
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1GetXy": {
-              "n_steps": 209,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 11
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1Mul": {
-              "n_steps": 125344,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 13961
-              },
-              "n_memory_holes": 0
-          },
-          "Secp256r1New": {
-              "n_steps": 580,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 49
-              },
-              "n_memory_holes": 0
-          },
-          "SendMessageToL1": {
-              "n_steps": 141,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "Sha256ProcessBlock": {
-              "n_steps": 1855,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 65,
-                  "bitwise_builtin": 1115
-              },
-              "n_memory_holes": 0
-          },
-          "StorageRead": {
-              "n_steps": 87,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          },
-          "StorageWrite": {
-              "n_steps": 89,
-              "builtin_instance_counter": {
-                  "range_check_builtin": 1
-              },
-              "n_memory_holes": 0
-          }
+    "execute_syscalls": {
+      "CallContract": {
+        "n_steps": 827,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
       },
-      "execute_txs_inner": {
-          "Declare": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 2973,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 16,
-                          "range_check_builtin": 53
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 0,
-                      "builtin_instance_counter": {},
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 3079,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 4,
-                          "range_check_builtin": 58,
-                          "poseidon_builtin": 10
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 0,
-                      "builtin_instance_counter": {},
-                      "n_memory_holes": 0
-                  }
-              }
-          },
-          "DeployAccount": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 4015,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 23,
-                          "range_check_builtin": 72
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 21,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 2
-                      },
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 4137,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 11,
-                          "range_check_builtin": 77,
-                          "poseidon_builtin": 10
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 21,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 2
-                      },
-                      "n_memory_holes": 0
-                  }
-              }
-          },
-          "InvokeFunction": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 3763,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 14,
-                          "range_check_builtin": 69
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 8,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 3904,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 4,
-                          "range_check_builtin": 74,
-                          "poseidon_builtin": 11
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 8,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              }
-          },
-          "L1Handler": {
-              "deprecated_resources": {
-                  "constant": {
-                      "n_steps": 1233,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 11,
-                          "range_check_builtin": 16
-                      },
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 13,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              },
-              "resources": {
-                  "constant": {
-                      "n_steps": 0,
-                      "builtin_instance_counter": {},
-                      "n_memory_holes": 0
-                  },
-                  "calldata_factor": {
-                      "n_steps": 13,
-                      "builtin_instance_counter": {
-                          "pedersen_builtin": 1
-                      },
-                      "n_memory_holes": 0
-                  }
-              }
-          }
+      "DelegateCall": {
+        "n_steps": 713,
+        "builtin_instance_counter": {
+          "range_check_builtin": 19
+        },
+        "n_memory_holes": 0
       },
-      "compute_os_kzg_commitment_info": {
-          "n_steps": 113,
-          "builtin_instance_counter": {
-              "range_check_builtin": 17
-          },
-          "n_memory_holes": 0
+      "DelegateL1Handler": {
+        "n_steps": 692,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "Deploy": {
+        "n_steps": 1097,
+        "builtin_instance_counter": {
+          "pedersen_builtin": 7,
+          "range_check_builtin": 18
+        },
+        "n_memory_holes": 0
+      },
+      "EmitEvent": {
+        "n_steps": 61,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetBlockHash": {
+        "n_steps": 104,
+        "builtin_instance_counter": {
+          "range_check_builtin": 2
+        },
+        "n_memory_holes": 0
+      },
+      "GetBlockNumber": {
+        "n_steps": 40,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "GetBlockTimestamp": {
+        "n_steps": 38,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "GetCallerAddress": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetContractAddress": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetExecutionInfo": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetSequencerAddress": {
+        "n_steps": 34,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "GetTxInfo": {
+        "n_steps": 64,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "GetTxSignature": {
+        "n_steps": 44,
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0
+      },
+      "Keccak": {
+        "n_steps": 381,
+        "builtin_instance_counter": {
+          "bitwise_builtin": 6,
+          "keccak_builtin": 1,
+          "range_check_builtin": 56
+        },
+        "n_memory_holes": 0
+      },
+      "LibraryCall": {
+        "n_steps": 818,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "LibraryCallL1Handler": {
+        "n_steps": 659,
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0
+      },
+      "ReplaceClass": {
+        "n_steps": 98,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1Add": {
+        "n_steps": 410,
+        "builtin_instance_counter": {
+          "range_check_builtin": 29
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1GetPointFromX": {
+        "n_steps": 395,
+        "builtin_instance_counter": {
+          "range_check_builtin": 30
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1GetXy": {
+        "n_steps": 207,
+        "builtin_instance_counter": {
+          "range_check_builtin": 11
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1Mul": {
+        "n_steps": 76505,
+        "builtin_instance_counter": {
+          "range_check_builtin": 7045
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256k1New": {
+        "n_steps": 461,
+        "builtin_instance_counter": {
+          "range_check_builtin": 35
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1Add": {
+        "n_steps": 593,
+        "builtin_instance_counter": {
+          "range_check_builtin": 57
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1GetPointFromX": {
+        "n_steps": 514,
+        "builtin_instance_counter": {
+          "range_check_builtin": 44
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1GetXy": {
+        "n_steps": 209,
+        "builtin_instance_counter": {
+          "range_check_builtin": 11
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1Mul": {
+        "n_steps": 125344,
+        "builtin_instance_counter": {
+          "range_check_builtin": 13961
+        },
+        "n_memory_holes": 0
+      },
+      "Secp256r1New": {
+        "n_steps": 580,
+        "builtin_instance_counter": {
+          "range_check_builtin": 49
+        },
+        "n_memory_holes": 0
+      },
+      "SendMessageToL1": {
+        "n_steps": 141,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "Sha256ProcessBlock": {
+        "n_steps": 1855,
+        "builtin_instance_counter": {
+          "range_check_builtin": 65,
+          "bitwise_builtin": 1115
+        },
+        "n_memory_holes": 0
+      },
+      "StorageRead": {
+        "n_steps": 87,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
+      },
+      "StorageWrite": {
+        "n_steps": 89,
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0
       }
+    },
+    "execute_txs_inner": {
+      "Declare": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 2973,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 16,
+              "range_check_builtin": 53
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 0,
+            "builtin_instance_counter": {},
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 3079,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 4,
+              "range_check_builtin": 58,
+              "poseidon_builtin": 10
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 0,
+            "builtin_instance_counter": {},
+            "n_memory_holes": 0
+          }
+        }
+      },
+      "DeployAccount": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 4015,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 23,
+              "range_check_builtin": 72
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 21,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 2
+            },
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 4137,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 11,
+              "range_check_builtin": 77,
+              "poseidon_builtin": 10
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 21,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 2
+            },
+            "n_memory_holes": 0
+          }
+        }
+      },
+      "InvokeFunction": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 3763,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 14,
+              "range_check_builtin": 69
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 8,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 3904,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 4,
+              "range_check_builtin": 74,
+              "poseidon_builtin": 11
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 8,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        }
+      },
+      "L1Handler": {
+        "deprecated_resources": {
+          "constant": {
+            "n_steps": 1233,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 11,
+              "range_check_builtin": 16
+            },
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 13,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        },
+        "resources": {
+          "constant": {
+            "n_steps": 0,
+            "builtin_instance_counter": {},
+            "n_memory_holes": 0
+          },
+          "calldata_factor": {
+            "n_steps": 13,
+            "builtin_instance_counter": {
+              "pedersen_builtin": 1
+            },
+            "n_memory_holes": 0
+          }
+        }
+      }
+    },
+    "compute_os_kzg_commitment_info": {
+      "n_steps": 113,
+      "builtin_instance_counter": {
+        "range_check_builtin": 17
+      },
+      "n_memory_holes": 0
+    }
   },
   "validate_max_n_steps": 1000000,
   "vm_resource_fee_cost": {
-      "add_mod_builtin": [
-          4,
-          100
-      ],
-      "bitwise_builtin": [
-          16,
-          100
-      ],
-      "ec_op_builtin": [
-          256,
-          100
-      ],
-      "ecdsa_builtin": [
-          512,
-          100
-      ],
-      "keccak_builtin": [
-          512,
-          100
-      ],
-      "mul_mod_builtin": [
-          4,
-          100
-      ],
-      "n_steps": [
-          25,
-          10000
-      ],
-      "output_builtin": [
-          0,
-          1
-      ],
-      "pedersen_builtin": [
-          8,
-          100
-      ],
-      "poseidon_builtin": [
-          8,
-          100
-      ],
-      "range_check_builtin": [
-          4,
-          100
-      ],
-      "range_check96_builtin": [
-          4,
-          100
-      ]
+    "add_mod_builtin": [4, 100],
+    "bitwise_builtin": [16, 100],
+    "ec_op_builtin": [256, 100],
+    "ecdsa_builtin": [512, 100],
+    "keccak_builtin": [512, 100],
+    "mul_mod_builtin": [4, 100],
+    "n_steps": [25, 10000],
+    "output_builtin": [0, 1],
+    "pedersen_builtin": [8, 100],
+    "poseidon_builtin": [8, 100],
+    "range_check_builtin": [4, 100],
+    "range_check96_builtin": [4, 100]
   }
 }

--- a/crates/sequencer/src/resources/versioned_constants.json
+++ b/crates/sequencer/src/resources/versioned_constants.json
@@ -1,555 +1,608 @@
 {
   "tx_event_limits": {
-    "max_data_length": 300,
-    "max_keys_length": 50,
-    "max_n_emitted_events": 1000
+      "max_data_length": 300,
+      "max_keys_length": 50,
+      "max_n_emitted_events": 1000
   },
   "gateway": {
-    "max_calldata_length": 5000,
-    "max_contract_bytecode_size": 81920
+      "max_calldata_length": 5000,
+      "max_contract_bytecode_size": 81920
   },
   "invoke_tx_max_n_steps": 50000000,
   "l2_resource_gas_costs": {
-    "gas_per_data_felt": [128, 1000],
-    "event_key_factor": [2, 1],
-    "gas_per_code_byte": [32, 1000]
+      "gas_per_data_felt": [
+          128,
+          1000
+      ],
+      "event_key_factor": [
+          2,
+          1
+      ],
+      "gas_per_code_byte": [
+          875,
+          1000
+      ]
   },
+  "disable_cairo0_redeclaration": true,
   "max_recursion_depth": 50,
-  "segment_arena_cells": true,
+  "segment_arena_cells": false,
   "os_constants": {
-    "nop_entry_point_offset": -1,
-    "entry_point_type_external": 0,
-    "entry_point_type_l1_handler": 1,
-    "entry_point_type_constructor": 2,
-    "l1_handler_version": 0,
-    "sierra_array_len_bound": 4294967296,
-    "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
-    "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
-    "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
-    "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
-    "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
-    "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
-    "default_entry_point_selector": 0,
-    "block_hash_contract_address": 1,
-    "stored_block_hash_buffer": 10,
-    "step_gas_cost": 100,
-    "range_check_gas_cost": 70,
-    "memory_hole_gas_cost": 10,
-    "initial_gas_cost": {
-      "step_gas_cost": 100000000
-    },
-    "entry_point_initial_budget": {
-      "step_gas_cost": 100
-    },
-    "syscall_base_gas_cost": {
-      "step_gas_cost": 100
-    },
-    "entry_point_gas_cost": {
-      "entry_point_initial_budget": 1,
-      "step_gas_cost": 500
-    },
-    "fee_transfer_gas_cost": {
-      "entry_point_gas_cost": 1,
-      "step_gas_cost": 100
-    },
-    "transaction_gas_cost": {
-      "entry_point_gas_cost": 2,
-      "fee_transfer_gas_cost": 1,
-      "step_gas_cost": 100
-    },
-    "call_contract_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 10,
-      "entry_point_gas_cost": 1
-    },
-    "deploy_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 200,
-      "entry_point_gas_cost": 1
-    },
-    "get_block_hash_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "get_execution_info_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 10
-    },
-    "library_call_gas_cost": {
-      "call_contract_gas_cost": 1
-    },
-    "replace_class_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "storage_read_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "storage_write_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "emit_event_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 10
-    },
-    "send_message_to_l1_gas_cost": {
-      "syscall_base_gas_cost": 1,
-      "step_gas_cost": 50
-    },
-    "secp256k1_add_gas_cost": {
-      "step_gas_cost": 406,
-      "range_check_gas_cost": 29
-    },
-    "secp256k1_get_point_from_x_gas_cost": {
-      "step_gas_cost": 391,
-      "range_check_gas_cost": 30,
-      "memory_hole_gas_cost": 20
-    },
-    "secp256k1_get_xy_gas_cost": {
-      "step_gas_cost": 239,
-      "range_check_gas_cost": 11,
-      "memory_hole_gas_cost": 40
-    },
-    "secp256k1_mul_gas_cost": {
-      "step_gas_cost": 76501,
-      "range_check_gas_cost": 7045,
-      "memory_hole_gas_cost": 2
-    },
-    "secp256k1_new_gas_cost": {
-      "step_gas_cost": 475,
-      "range_check_gas_cost": 35,
-      "memory_hole_gas_cost": 40
-    },
-    "secp256r1_add_gas_cost": {
-      "step_gas_cost": 589,
-      "range_check_gas_cost": 57
-    },
-    "secp256r1_get_point_from_x_gas_cost": {
-      "step_gas_cost": 510,
-      "range_check_gas_cost": 44,
-      "memory_hole_gas_cost": 20
-    },
-    "secp256r1_get_xy_gas_cost": {
-      "step_gas_cost": 241,
-      "range_check_gas_cost": 11,
-      "memory_hole_gas_cost": 40
-    },
-    "secp256r1_mul_gas_cost": {
-      "step_gas_cost": 125340,
-      "range_check_gas_cost": 13961,
-      "memory_hole_gas_cost": 2
-    },
-    "secp256r1_new_gas_cost": {
-      "step_gas_cost": 594,
-      "range_check_gas_cost": 49,
-      "memory_hole_gas_cost": 40
-    },
-    "keccak_gas_cost": {
-      "syscall_base_gas_cost": 1
-    },
-    "keccak_round_cost_gas_cost": 180000,
-    "sha256_process_block_gas_cost": {
-      "step_gas_cost": 0,
-      "range_check_gas_cost": 0,
-      "syscall_base_gas_cost": 0
-    },
-    "error_block_number_out_of_range": "Block number out of range",
-    "error_out_of_gas": "Out of gas",
-    "error_invalid_input_len": "Invalid input length",
-    "error_invalid_argument": "Invalid argument",
-    "validated": "VALID",
-    "l1_gas": "L1_GAS",
-    "l2_gas": "L2_GAS",
-    "l1_gas_index": 0,
-    "l2_gas_index": 1,
-    "validate_rounding_consts": {
-      "validate_block_number_rounding": 100,
-      "validate_timestamp_rounding": 3600
-    }
+      "block_hash_contract_address": 1,
+      "call_contract_gas_cost": {
+          "entry_point_gas_cost": 1,
+          "step_gas_cost": 10,
+          "syscall_base_gas_cost": 1
+      },
+      "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+      "default_entry_point_selector": 0,
+      "deploy_gas_cost": {
+          "entry_point_gas_cost": 1,
+          "step_gas_cost": 200,
+          "syscall_base_gas_cost": 1
+      },
+      "emit_event_gas_cost": {
+          "step_gas_cost": 10,
+          "syscall_base_gas_cost": 1
+      },
+      "entry_point_gas_cost": {
+          "entry_point_initial_budget": 1,
+          "step_gas_cost": 500
+      },
+      "entry_point_initial_budget": {
+          "step_gas_cost": 100
+      },
+      "entry_point_type_constructor": 2,
+      "entry_point_type_external": 0,
+      "entry_point_type_l1_handler": 1,
+      "error_block_number_out_of_range": "Block number out of range",
+      "error_invalid_input_len": "Invalid input length",
+      "error_invalid_argument": "Invalid argument",
+      "error_out_of_gas": "Out of gas",
+      "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+      "fee_transfer_gas_cost": {
+          "entry_point_gas_cost": 1,
+          "step_gas_cost": 100
+      },
+      "get_block_hash_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "get_execution_info_gas_cost": {
+          "step_gas_cost": 10,
+          "syscall_base_gas_cost": 1
+      },
+      "initial_gas_cost": {
+          "step_gas_cost": 100000000
+      },
+      "keccak_gas_cost": {
+          "syscall_base_gas_cost": 1
+      },
+      "keccak_round_cost_gas_cost": 180000,
+      "l1_gas": "L1_GAS",
+      "l1_gas_index": 0,
+      "l1_handler_version": 0,
+      "l2_gas": "L2_GAS",
+      "l2_gas_index": 1,
+      "library_call_gas_cost": {
+          "call_contract_gas_cost": 1
+      },
+      "sha256_process_block_gas_cost": {
+          "step_gas_cost": 1852,
+          "range_check_gas_cost": 65,
+          "bitwise_builtin_gas_cost": 1115,
+          "syscall_base_gas_cost": 1
+      },
+      "memory_hole_gas_cost": 10,
+      "nop_entry_point_offset": -1,
+      "range_check_gas_cost": 70,
+      "bitwise_builtin_gas_cost": 594,
+      "replace_class_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "secp256k1_add_gas_cost": {
+          "range_check_gas_cost": 29,
+          "step_gas_cost": 406
+      },
+      "secp256k1_get_point_from_x_gas_cost": {
+          "memory_hole_gas_cost": 20,
+          "range_check_gas_cost": 30,
+          "step_gas_cost": 391
+      },
+      "secp256k1_get_xy_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 11,
+          "step_gas_cost": 239
+      },
+      "secp256k1_mul_gas_cost": {
+          "memory_hole_gas_cost": 2,
+          "range_check_gas_cost": 7045,
+          "step_gas_cost": 76501
+      },
+      "secp256k1_new_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 35,
+          "step_gas_cost": 475
+      },
+      "secp256r1_add_gas_cost": {
+          "range_check_gas_cost": 57,
+          "step_gas_cost": 589
+      },
+      "secp256r1_get_point_from_x_gas_cost": {
+          "memory_hole_gas_cost": 20,
+          "range_check_gas_cost": 44,
+          "step_gas_cost": 510
+      },
+      "secp256r1_get_xy_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 11,
+          "step_gas_cost": 241
+      },
+      "secp256r1_mul_gas_cost": {
+          "memory_hole_gas_cost": 2,
+          "range_check_gas_cost": 13961,
+          "step_gas_cost": 125340
+      },
+      "secp256r1_new_gas_cost": {
+          "memory_hole_gas_cost": 40,
+          "range_check_gas_cost": 49,
+          "step_gas_cost": 594
+      },
+      "send_message_to_l1_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "sierra_array_len_bound": 4294967296,
+      "step_gas_cost": 100,
+      "storage_read_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "storage_write_gas_cost": {
+          "step_gas_cost": 50,
+          "syscall_base_gas_cost": 1
+      },
+      "stored_block_hash_buffer": 10,
+      "syscall_base_gas_cost": {
+          "step_gas_cost": 100
+      },
+      "transaction_gas_cost": {
+          "entry_point_gas_cost": 2,
+          "fee_transfer_gas_cost": 1,
+          "step_gas_cost": 100
+      },
+      "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+      "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+      "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+      "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+      "validate_rounding_consts": {
+          "validate_block_number_rounding": 100,
+          "validate_timestamp_rounding": 3600
+      },
+      "validated": "VALID"
   },
   "os_resources": {
-    "execute_syscalls": {
-      "CallContract": {
-        "n_steps": 760,
-        "builtin_instance_counter": {
-          "range_check_builtin": 20
-        },
-        "n_memory_holes": 0
-      },
-      "DelegateCall": {
-        "n_steps": 713,
-        "builtin_instance_counter": {
-          "range_check_builtin": 19
-        },
-        "n_memory_holes": 0
-      },
-      "DelegateL1Handler": {
-        "n_steps": 692,
-        "builtin_instance_counter": {
-          "range_check_builtin": 15
-        },
-        "n_memory_holes": 0
-      },
-      "Deploy": {
-        "n_steps": 1012,
-        "builtin_instance_counter": {
-          "pedersen_builtin": 7,
-          "range_check_builtin": 19
-        },
-        "n_memory_holes": 0
-      },
-      "EmitEvent": {
-        "n_steps": 61,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetBlockHash": {
-        "n_steps": 104,
-        "builtin_instance_counter": {
-          "range_check_builtin": 2
-        },
-        "n_memory_holes": 0
-      },
-      "GetBlockNumber": {
-        "n_steps": 40,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "GetBlockTimestamp": {
-        "n_steps": 38,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "GetCallerAddress": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetContractAddress": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetExecutionInfo": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetSequencerAddress": {
-        "n_steps": 34,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "GetTxInfo": {
-        "n_steps": 64,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "GetTxSignature": {
-        "n_steps": 44,
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0
-      },
-      "Keccak": {
-        "n_steps": 381,
-        "builtin_instance_counter": {
-          "bitwise_builtin": 6,
-          "keccak_builtin": 1,
-          "range_check_builtin": 56
-        },
-        "n_memory_holes": 0
-      },
-      "LibraryCall": {
-        "n_steps": 751,
-        "builtin_instance_counter": {
-          "range_check_builtin": 20
-        },
-        "n_memory_holes": 0
-      },
-      "LibraryCallL1Handler": {
-        "n_steps": 659,
-        "builtin_instance_counter": {
-          "range_check_builtin": 15
-        },
-        "n_memory_holes": 0
-      },
-      "ReplaceClass": {
-        "n_steps": 98,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1Add": {
-        "n_steps": 408,
-        "builtin_instance_counter": {
-          "range_check_builtin": 29
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1GetPointFromX": {
-        "n_steps": 393,
-        "builtin_instance_counter": {
-          "range_check_builtin": 30
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1GetXy": {
-        "n_steps": 205,
-        "builtin_instance_counter": {
-          "range_check_builtin": 11
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1Mul": {
-        "n_steps": 76503,
-        "builtin_instance_counter": {
-          "range_check_builtin": 7045
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256k1New": {
-        "n_steps": 459,
-        "builtin_instance_counter": {
-          "range_check_builtin": 35
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1Add": {
-        "n_steps": 591,
-        "builtin_instance_counter": {
-          "range_check_builtin": 57
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1GetPointFromX": {
-        "n_steps": 512,
-        "builtin_instance_counter": {
-          "range_check_builtin": 44
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1GetXy": {
-        "n_steps": 207,
-        "builtin_instance_counter": {
-          "range_check_builtin": 11
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1Mul": {
-        "n_steps": 125342,
-        "builtin_instance_counter": {
-          "range_check_builtin": 13961
-        },
-        "n_memory_holes": 0
-      },
-      "Secp256r1New": {
-        "n_steps": 578,
-        "builtin_instance_counter": {
-          "range_check_builtin": 49
-        },
-        "n_memory_holes": 0
-      },
-      "SendMessageToL1": {
-        "n_steps": 139,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "Sha256ProcessBlock": {
-        "builtin_instance_counter": {},
-        "n_memory_holes": 0,
-        "n_steps": 0
-      },
-      "StorageRead": {
-        "n_steps": 87,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      },
-      "StorageWrite": {
-        "n_steps": 89,
-        "builtin_instance_counter": {
-          "range_check_builtin": 1
-        },
-        "n_memory_holes": 0
-      }
-    },
-    "execute_txs_inner": {
-      "Declare": {
-        "resources": {
-          "constant": {
-            "n_steps": 2839,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 16,
-              "range_check_builtin": 63
-            },
-            "n_memory_holes": 0
+      "execute_syscalls": {
+          "CallContract": {
+              "n_steps": 827,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
           },
-          "calldata_factor": {
-            "n_steps": 0,
-            "builtin_instance_counter": {},
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 2839,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 16,
-              "range_check_builtin": 63
-            },
-            "n_memory_holes": 0
+          "DelegateCall": {
+              "n_steps": 713,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 19
+              },
+              "n_memory_holes": 0
           },
-          "calldata_factor": {
-            "n_steps": 0,
-            "builtin_instance_counter": {},
-            "n_memory_holes": 0
+          "DelegateL1Handler": {
+              "n_steps": 692,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
+          },
+          "Deploy": {
+              "n_steps": 1097,
+              "builtin_instance_counter": {
+                  "pedersen_builtin": 7,
+                  "range_check_builtin": 18
+              },
+              "n_memory_holes": 0
+          },
+          "EmitEvent": {
+              "n_steps": 61,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetBlockHash": {
+              "n_steps": 104,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 2
+              },
+              "n_memory_holes": 0
+          },
+          "GetBlockNumber": {
+              "n_steps": 40,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "GetBlockTimestamp": {
+              "n_steps": 38,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "GetCallerAddress": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetContractAddress": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetExecutionInfo": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetSequencerAddress": {
+              "n_steps": 34,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "GetTxInfo": {
+              "n_steps": 64,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "GetTxSignature": {
+              "n_steps": 44,
+              "builtin_instance_counter": {},
+              "n_memory_holes": 0
+          },
+          "Keccak": {
+              "n_steps": 381,
+              "builtin_instance_counter": {
+                  "bitwise_builtin": 6,
+                  "keccak_builtin": 1,
+                  "range_check_builtin": 56
+              },
+              "n_memory_holes": 0
+          },
+          "LibraryCall": {
+              "n_steps": 818,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
+          },
+          "LibraryCallL1Handler": {
+              "n_steps": 659,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 15
+              },
+              "n_memory_holes": 0
+          },
+          "ReplaceClass": {
+              "n_steps": 98,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1Add": {
+              "n_steps": 410,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 29
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1GetPointFromX": {
+              "n_steps": 395,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 30
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1GetXy": {
+              "n_steps": 207,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 11
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1Mul": {
+              "n_steps": 76505,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 7045
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256k1New": {
+              "n_steps": 461,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 35
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1Add": {
+              "n_steps": 593,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 57
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1GetPointFromX": {
+              "n_steps": 514,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 44
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1GetXy": {
+              "n_steps": 209,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 11
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1Mul": {
+              "n_steps": 125344,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 13961
+              },
+              "n_memory_holes": 0
+          },
+          "Secp256r1New": {
+              "n_steps": 580,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 49
+              },
+              "n_memory_holes": 0
+          },
+          "SendMessageToL1": {
+              "n_steps": 141,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "Sha256ProcessBlock": {
+              "n_steps": 1855,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 65,
+                  "bitwise_builtin": 1115
+              },
+              "n_memory_holes": 0
+          },
+          "StorageRead": {
+              "n_steps": 87,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
+          },
+          "StorageWrite": {
+              "n_steps": 89,
+              "builtin_instance_counter": {
+                  "range_check_builtin": 1
+              },
+              "n_memory_holes": 0
           }
-        }
       },
-      "DeployAccount": {
-        "resources": {
-          "constant": {
-            "n_steps": 3792,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 23,
-              "range_check_builtin": 83
-            },
-            "n_memory_holes": 0
+      "execute_txs_inner": {
+          "Declare": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 2973,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 16,
+                          "range_check_builtin": 53
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 0,
+                      "builtin_instance_counter": {},
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 3079,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 4,
+                          "range_check_builtin": 58,
+                          "poseidon_builtin": 10
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 0,
+                      "builtin_instance_counter": {},
+                      "n_memory_holes": 0
+                  }
+              }
           },
-          "calldata_factor": {
-            "n_steps": 21,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 2
-            },
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 3792,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 23,
-              "range_check_builtin": 83
-            },
-            "n_memory_holes": 0
+          "DeployAccount": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 4015,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 23,
+                          "range_check_builtin": 72
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 21,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 2
+                      },
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 4137,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 11,
+                          "range_check_builtin": 77,
+                          "poseidon_builtin": 10
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 21,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 2
+                      },
+                      "n_memory_holes": 0
+                  }
+              }
           },
-          "calldata_factor": {
-            "n_steps": 21,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 2
-            },
-            "n_memory_holes": 0
+          "InvokeFunction": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 3763,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 14,
+                          "range_check_builtin": 69
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 8,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 3904,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 4,
+                          "range_check_builtin": 74,
+                          "poseidon_builtin": 11
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 8,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              }
+          },
+          "L1Handler": {
+              "deprecated_resources": {
+                  "constant": {
+                      "n_steps": 1233,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 11,
+                          "range_check_builtin": 16
+                      },
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 13,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              },
+              "resources": {
+                  "constant": {
+                      "n_steps": 0,
+                      "builtin_instance_counter": {},
+                      "n_memory_holes": 0
+                  },
+                  "calldata_factor": {
+                      "n_steps": 13,
+                      "builtin_instance_counter": {
+                          "pedersen_builtin": 1
+                      },
+                      "n_memory_holes": 0
+                  }
+              }
           }
-        }
       },
-      "InvokeFunction": {
-        "resources": {
-          "constant": {
-            "n_steps": 3546,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 14,
-              "range_check_builtin": 80
-            },
-            "n_memory_holes": 0
-          },
-          "calldata_factor": {
-            "n_steps": 8,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 3546,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 14,
-              "range_check_builtin": 80
-            },
-            "n_memory_holes": 0
-          },
-          "calldata_factor": {
-            "n_steps": 8,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        }
-      },
-      "L1Handler": {
-        "resources": {
-          "constant": {
-            "n_steps": 1146,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 11,
+      "compute_os_kzg_commitment_info": {
+          "n_steps": 113,
+          "builtin_instance_counter": {
               "range_check_builtin": 17
-            },
-            "n_memory_holes": 0
           },
-          "calldata_factor": {
-            "n_steps": 13,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        },
-        "deprecated_resources": {
-          "constant": {
-            "n_steps": 1146,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 11,
-              "range_check_builtin": 17
-            },
-            "n_memory_holes": 0
-          },
-          "calldata_factor": {
-            "n_steps": 13,
-            "builtin_instance_counter": {
-              "pedersen_builtin": 1
-            },
-            "n_memory_holes": 0
-          }
-        }
+          "n_memory_holes": 0
       }
-    },
-    "compute_os_kzg_commitment_info": {
-      "n_steps": 0,
-      "builtin_instance_counter": {},
-      "n_memory_holes": 0
-    }
   },
   "validate_max_n_steps": 1000000,
   "vm_resource_fee_cost": {
-    "add_mod_builtin": [0, 1],
-    "bitwise_builtin": [16, 100],
-    "ec_op_builtin": [256, 100],
-    "ecdsa_builtin": [512, 100],
-    "keccak_builtin": [512, 100],
-    "mul_mod_builtin": [0, 1],
-    "n_steps": [25, 10000],
-    "output_builtin": [0, 1],
-    "pedersen_builtin": [8, 100],
-    "poseidon_builtin": [8, 100],
-    "range_check_builtin": [4, 100],
-    "range_check96_builtin": [0, 1]
+      "add_mod_builtin": [
+          4,
+          100
+      ],
+      "bitwise_builtin": [
+          16,
+          100
+      ],
+      "ec_op_builtin": [
+          256,
+          100
+      ],
+      "ecdsa_builtin": [
+          512,
+          100
+      ],
+      "keccak_builtin": [
+          512,
+          100
+      ],
+      "mul_mod_builtin": [
+          4,
+          100
+      ],
+      "n_steps": [
+          25,
+          10000
+      ],
+      "output_builtin": [
+          0,
+          1
+      ],
+      "pedersen_builtin": [
+          8,
+          100
+      ],
+      "poseidon_builtin": [
+          8,
+          100
+      ],
+      "range_check_builtin": [
+          4,
+          100
+      ],
+      "range_check96_builtin": [
+          4,
+          100
+      ]
   }
 }


### PR DESCRIPTION
# Pull Request type


The file used was for update 0.13.1.1, while the blockifier fork we use was version 0.13.2. This caused some issues with the pricing of syscalls.
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR:

Resolves: #{Issue number}

<!-- Please try to limit your pull request to one type;
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
