### PR TITLE
chore: bump tx gas available in transactions

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,11 +2,11 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.18.1
+  version: 1.22.5
 plugins:
   sources:
     - id: trunk
-      ref: v1.4.1
+      ref: v1.6.2
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
@@ -27,21 +27,21 @@ lint:
         - crates/ef-testing/src/evm_sequencer/constants.rs
         - crates/ef-testing/tests/**/*.rs
   enabled:
-    - actionlint@1.6.26
-    - black@23.12.0
-    - checkov@3.1.40
+    - actionlint@1.7.1
+    - black@24.8.0
+    - checkov@3.2.251
     - clippy@SYSTEM
     - git-diff-check
     - isort@5.13.2
-    - markdownlint@0.38.0
-    - osv-scanner@1.5.0
-    - prettier@3.1.1
-    - ruff@0.1.8
+    - markdownlint@0.41.0
+    - osv-scanner@1.8.5
+    - prettier@3.3.3
+    - ruff@0.6.4
     - rustfmt@1.65.0
-    - taplo@0.8.1
-    - trivy@0.48.1
-    - trufflehog@3.63.5
-    - yamllint@1.33.0
+    - taplo@0.9.3
+    - trivy@0.55.0
+    - trufflehog@3.81.10
+    - yamllint@1.35.1
 actions:
   disabled:
     - trunk-announce

--- a/crates/ef-testing/src/evm_sequencer/sequencer/resources/versioned_constants.json
+++ b/crates/ef-testing/src/evm_sequencer/sequencer/resources/versioned_constants.json
@@ -63,7 +63,7 @@
       "syscall_base_gas_cost": 1
     },
     "initial_gas_cost": {
-      "step_gas_cost": 100000000
+      "step_gas_cost": 500000000
     },
     "keccak_gas_cost": {
       "syscall_base_gas_cost": 1

--- a/crates/sequencer/src/resources/versioned_constants.json
+++ b/crates/sequencer/src/resources/versioned_constants.json
@@ -63,7 +63,7 @@
       "syscall_base_gas_cost": 1
     },
     "initial_gas_cost": {
-      "step_gas_cost": 100000000
+      "step_gas_cost": 500000000
     },
     "keccak_gas_cost": {
       "syscall_base_gas_cost": 1


### PR DESCRIPTION
# Pull Request type

<!--- Please provide a general summary of your changes in the title above -->

The execution of a transaction is bounded by two constraints:
- The amount of steps available in the environment - a hard limit that, if reached, will stop the execution ungracefully
- The amount of __gas__ (similar to EVM Gas) available in the environment - if reached, the execution will be stopped gracefully.

In the verisoned_constants.json file, we update the max steps limit, without updating the gas limit. This lead to tests that would fail because reaching an 'Out of gas' limit, different from a hard step limit.

Time spent on this PR:

Resolves: #{Issue number}

<!-- Please try to limit your pull request to one type;
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
