### PR TITLE
feat: update base_fee storage location mirroring kakarot new strategy

### DIFF
--- a/crates/ef-testing/src/evm_sequencer/evm_state/mod.rs
+++ b/crates/ef-testing/src/evm_sequencer/evm_state/mod.rs
@@ -103,9 +103,11 @@ impl Evm for KakarotSequencer {
             coinbase_address,
         )?;
 
-        // Set the base fee.
+        // Set the base fee at index 'current_block'
         let [low_fee, high_fee] = split_u256(base_fee);
-        let basefee_address = get_storage_var_address(KAKAROT_BASE_FEE, &[]);
+        let key = Felt::from_bytes_be_slice(&"current_block".as_bytes());
+        println!("key: {:?}", key);
+        let basefee_address = get_storage_var_address(KAKAROT_BASE_FEE, &[key]);
         self.state_mut()
             .set_storage_at(kakarot_address, basefee_address, low_fee.into())?;
         self.state_mut().set_storage_at(

--- a/crates/ef-testing/src/evm_sequencer/evm_state/mod.rs
+++ b/crates/ef-testing/src/evm_sequencer/evm_state/mod.rs
@@ -105,7 +105,7 @@ impl Evm for KakarotSequencer {
 
         // Set the base fee at index 'current_block'
         let [low_fee, high_fee] = split_u256(base_fee);
-        let key = Felt::from_bytes_be_slice(&"current_block".as_bytes());
+        let key = Felt::from_bytes_be_slice("current_block".as_bytes());
         println!("key: {:?}", key);
         let basefee_address = get_storage_var_address(KAKAROT_BASE_FEE, &[key]);
         self.state_mut()

--- a/crates/ef-testing/src/evm_sequencer/evm_state/mod.rs
+++ b/crates/ef-testing/src/evm_sequencer/evm_state/mod.rs
@@ -105,7 +105,7 @@ impl Evm for KakarotSequencer {
 
         // Set the base fee at index 'current_block'
         let [low_fee, high_fee] = split_u256(base_fee);
-        let key = Felt::from_bytes_be_slice("current_block".as_bytes());
+        let key = Felt::from_bytes_be_slice(b"current_block");
         println!("key: {:?}", key);
         let basefee_address = get_storage_var_address(KAKAROT_BASE_FEE, &[key]);
         self.state_mut()


### PR DESCRIPTION
uses the value inside the `current_block` index of the Kakarot_base_fee storage var as the base fee to use when running test.