### PR TITLE
Fix Typographical Error Update compute_resources.py

### DIFF
--- a/scripts/compute_resources.py
+++ b/scripts/compute_resources.py
@@ -22,7 +22,7 @@ def get_resource_usage(path: str = "./test.out"):
     # Remove ANSI escape sequences
     cleaned_output = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", result)
     matches = re.findall(
-        r"ef_testing::models::result: (.*) passed: .?ResourcesMapping\((.*)\)",
+        r"ef_testing::models::result: (.*) passed: ResourcesMapping\((.*)\)",
         cleaned_output,
     )
     tests_resources = [


### PR DESCRIPTION
**Summary of Change**:  
This pull request addresses a small typographical error in the regular expression pattern within the `get_resource_usage` function.

**Original Code**:  
```python
r"ef_testing::models::result: (.*) passed: .?ResourcesMapping\((.*)\)"
```

**Corrected Code**:  
```python
r"ef_testing::models::result: (.*) passed: ResourcesMapping\((.*)\)"
```

**Reason for Change**:  
The dot (`.`) in the original regular expression `.?ResourcesMapping` is unnecessary and likely a typo. It matches zero or one character before the `ResourcesMapping` text, which could cause incorrect matches. The intended pattern should directly match "passed:" followed by `ResourcesMapping`, without allowing any characters in between. Removing the dot ensures that the pattern matches the exact string "passed: ResourcesMapping" correctly.

**Impact**:  
This change is important because it ensures the regular expression behaves as expected, leading to more accurate parsing of the output. Without this correction, the regular expression could match unwanted results or fail to properly capture the intended data, potentially leading to issues in further processing or inaccurate results.

---

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
