### PR TITLE
Fix typos and improve readability in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repository contains the execution of the EF standard execution layer tests.
 
 The Ethereum Foundation provides a suite of
 [official tests](https://github.com/ethereum/tests) to verify the compliance of
-EVM clients. Passing all these tests qualifies allows a client to gain
-confidence on his execution layer. For further information, please refer to the
+EVM clients. Passing all these tests allows a client to gain
+confidence on their execution layer. For further information, please refer to the
 [official documentation](https://ethereum-tests.readthedocs.io/en/latest/).
 
 Kakarot is an EVM running within CairoVM, coupled with a
@@ -36,7 +36,7 @@ instructions:
 
 ## Test execution
 
-To run the whole test suite, execute `make ef-test` To run a specific test or
+To run the whole test suite, execute `make ef-test` to run a specific test or
 list of tests, execute `cargo test regular_expression` where regular_expression
 allows you to filter on the specific tests you want to run.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,15 +12,15 @@ the repository:
 
 - Integrator: adds a test suite, runs the suite, makes an issue for each failing
   test, marks failing tests as skipped.
-- Debugger: picks an issue raised by a Integrator, and dives in the EVM spec and
-  the current Cairo 0 implementation in order to pin point the exact issue. Ones
+- Debugger: picks an issue raised by an Integrator, and dives in the EVM spec and
+  the current Cairo 0 implementation in order to pin point the exact issue. Once
   the issue is correctly understood, checks if a similar issue hasn't been
   raised by another Debugger yet. If it has, link the Integrator issue to the
   Debugger issue for tracking and pick up another Integrator issue. If it
-  hasn't, raises a detailed issue about the Cairo 0 implementation bug and links
+  hasn't, raises a detailed issue about the  Cairo 0 implementation bug and links
   it to the Integrator issue.
-- Implementor: picks up an detailed issue raised by a Debugger and reimplements
-  the test logic in Cairo 0 python tests. Once the error is replicated, fixes
+- Implementor: picks up a detailed issue raised by a Debugger and reimplements
+  the test logic in Cairo 0 Python tests. Once the error is replicated, fixes
   the test in Cairo 0.
 
 ## How to
@@ -42,7 +42,7 @@ To start:
   `make ef-tests`. After a while (count 10-15 minutes) the test will end and you
   should have in your terminal's output a list of all the failing tests.
 - Start making issues. When raising issues, please try to match other
-  `Integrator` issued on the style, and don't forget to add any raised issue to
+  `Integrator` issues on the style, and don't forget to add any raised issue to
   the `epic` issue's task list.
 
 Please find [here](https://github.com/kkrt-labs/ef-tests/issues/52) an example
@@ -55,7 +55,7 @@ Pick an issue from the available `Integrator` issues. Verify that the test fails
 it does, you can start debugging it. The following documentation can be used:
 
 - [Test fillers](https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller):
-  used to generated the actual test. This can be used to understand what code
+  used to generate the actual test. This can be used to understand what code
   the transaction executes.
 - [Execution specs](https://github.com/ethereum/execution-specs/tree/master):
   Ethereum execution specifications written in Python. This can be used to
@@ -82,10 +82,10 @@ Ethereum/test:
   blockifier = { git = "https://github.com/jobez/blockifier.git", rev = "7f00407" }
   ```
 
-- In the file `./kakarot-rpc/lib/kakarot/src/kakarot/instructions.cairo`, add
+- In the file `./kakarot-rpc/lib/kakarot/src/kakarot/instructions.`, add
   the following hint `%{print(ids.opcode, ids.ctx) %}` right after line 65. See
   the following
-  [gist](https://gist.github.com/jobez/42941db9361d81778abd36309dfb60dc#file-instructions-cairo-L68-L70)
+  [gist](https://gist.github.com/jobez/42941db9361d81778abd36309dfb60dc#file-instructions--L68-L70)
   for more details.
 - From the root of the `kakarot-rpc` repository, run the following:
 
@@ -124,10 +124,10 @@ allowing for better tracing of the error. In order to set this up:
   folder for help.
 - Call `eth_send_transaction` with the exact same arguments as the transaction
   from your test. If the error you get is the same as the error on the ef-tests
-  repository, you can now start debugging using hints in the Cairo 0 code.
+  repository, you can now start debugging using hints in the 0 code.
 - In order to run only your test, use `poetry run pytest -k your_test_name`.
-- Debug the Cairo 0 code by adding `%{print(ids.x)%}` to print variables (where
-  x is the variable you want to print). Be sure to recompile your Cairo 0 code
+- Debug the  0 code by adding `%{print(ids.x)%}` to print variables (where
+  x is the variable you want to print). Be sure to recompile your  0 code
   EVERY TIME you make changes, by running `make build`.
 
 ### Implementor


### PR DESCRIPTION
- Corrected grammar and word usage in the "About" section (e.g., changed "confidence on his execution layer" to "confidence on their execution layer").
- Fixed minor typos and improved phrasing in the "Contributing" guide.
- Corrected the inconsistency in the capitalization of "Python" and "Cairo 0".
- Improved readability and consistency across sections, including fixing sentence structures and punctuation.